### PR TITLE
[Refactor]: #21 Remove usage of __annotations__

### DIFF
--- a/src/fastdataframe/core/model.py
+++ b/src/fastdataframe/core/model.py
@@ -109,7 +109,7 @@ class FastDataframeModel(BaseModel):
         return new_model
 
     @classmethod
-    def get_column_infos(
+    def model_columns(
         cls, alias_type: AliasType = "serialization"
     ) -> dict[str, ColumnInfo]:
         """Return a dictionary mapping field_name to ColumnInfo objects from the model_json_schema."""

--- a/src/fastdataframe/polars/model.py
+++ b/src/fastdataframe/polars/model.py
@@ -72,10 +72,8 @@ class PolarsFastDataframeModel(FastDataframeModel):
         )
         return pl.Schema(
             {
-                alias_func(
-                    cls.__pydantic_fields__[field_name], field_name
-                ): get_polars_type(field_type)
-                for field_name, field_type in cls.__annotations__.items()
+                alias_func(field_info, field_name): get_polars_type(field_info)
+                for field_name, field_info in cls.model_fields.items()
             }
         )
 
@@ -91,8 +89,8 @@ class PolarsFastDataframeModel(FastDataframeModel):
         )
         return pl.Schema(
             {
-                alias_func(cls.__pydantic_fields__[field_name], field_name): pl.String
-                for field_name in cls.__annotations__.keys()
+                alias_func(field_info, field_name): pl.String
+                for field_name, field_info in cls.model_fields.items()
             }
         )
 

--- a/src/fastdataframe/polars/model.py
+++ b/src/fastdataframe/polars/model.py
@@ -236,7 +236,7 @@ class PolarsFastDataframeModel(FastDataframeModel):
         """
         source_schema = df.collect_schema()
         target_schema = cls.get_polars_schema(alias_type)
-        column_infos = cls.get_column_infos(alias_type)
+        column_infos = cls.model_columns(alias_type)
         cast_functions = []
 
         for target_col, target_type in target_schema.items():

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -115,7 +115,7 @@ class TestFastDataframeModel:
             field3: Optional[float] = None
             field4: Annotated[bool, ColumnInfo(is_unique=True)]
 
-        annotations = MyModel.get_column_infos()
+        annotations = MyModel.model_columns()
         assert isinstance(annotations, dict)
         assert "field1" in annotations
         assert "field2" in annotations

--- a/tests/polars/test_model.py
+++ b/tests/polars/test_model.py
@@ -382,7 +382,7 @@ class TestPolarsValidation:
         PolarsModel = PolarsFastDataframeModel.from_base_model(UserTestModel)
         assert issubclass(PolarsModel, PolarsFastDataframeModel)
         assert PolarsModel.__name__ == "UserTestModelPolars"
-        assert PolarsModel.__annotations__ == UserTestModel.__annotations__
+        assert PolarsModel.model_fields.keys() == UserTestModel.model_fields.keys()
         assert PolarsModel.__doc__ == "Polars version of UserTestModel"
         polars_json_schema = PolarsModel.model_json_schema()
         base_json_shema = UserTestModel.model_json_schema()


### PR DESCRIPTION
- Remove all the usage of `__annotations__`
- Rename `get_column_info` to 'model_columns`
