### PR TITLE
Migrate build system from hatchling to uv build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.9.21,<0.10.0"]
+build-backend = "uv_build"
 
 [project]
 name = "fastdataframe"
@@ -68,8 +68,3 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/fastdataframe"]
-include = [
-    "src/fastdataframe/py.typed"
-]


### PR DESCRIPTION
This PR migrates the build system from hatchling to the new uv build backend.

## Changes
- Updated [build-system] to use `uv_build>=0.9.21,<0.10.0`
- Removed hatch-specific `[tool.hatch.build.targets.wheel]` configuration
- Verified build works correctly with `uv build`

## Benefits
- Faster builds with uv's native backend
- Better integration with uv tooling
- Zero configuration needed for standard src/ layout

Closes #45