### PR TITLE
Rewrite FastDataFrame core schema API

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# FastDataFrame
+
+FastDataFrame defines dataframe schemas from Pydantic models and translates them into backend-specific schemas for dataframe processing and lakehouse storage.
+
+## Language
+
+**Pydantic Model**:
+The user-authored data contract that declares fields, Python types, aliases, and validation behavior. It is the public declaration surface for a dataframe schema.
+_Avoid_: Base schema, source class
+
+**ColumnInfo**:
+User-authored column metadata attached to a Pydantic field for dataframe and lakehouse concerns that are not part of the Python type itself. It contains user intent, including optional backend-neutral dtype refinements, not resolved backend-native types.
+_Avoid_: Column definition, field definition
+
+**Dtype**:
+A backend-neutral logical column type declared in ColumnInfo to refine the Python annotation for dataframe and table schema generation. Initial Dtypes are scalar refinements; container shapes are derived from Python annotations. A Dtype must be compatible with the field's Python annotation and mappable to each supported backend, though some backends may widen representation such as small signed integers in Iceberg.
+_Avoid_: Strict type, Polars type, Arrow type, Iceberg type when referring to the backend-neutral concept
+
+**ColumnDefinition**:
+The backend-neutral, immutable, normalized representation of one dataframe column owned by a FastDataFrameModel class, analogous to how Pydantic BaseModel owns model fields. It is derived from a Pydantic field and optional ColumnInfo metadata; backend implementations consume ColumnDefinitions rather than raw Pydantic field objects. ColumnDefinitions include resolved names, Python/Pydantic type information, nullability, requiredness, defaults, constraints, and ColumnInfo; they do not contain backend-native types. ColumnDefinitions are built lazily by default and may be built eagerly only for backend-neutral validation.
+_Avoid_: ColumnInfo, FieldInfo, backend column
+
+**Storage Name**:
+The canonical dataframe and table column name for a ColumnDefinition. It defaults to the Pydantic serialization name.
+_Avoid_: Validation name, Python name when referring to persisted dataframe/table columns
+
+**Name Accessor**:
+A read-only class-owned helper that exposes resolved column names as attributes, such as `User.serialization_names.user_id` or `User.validation_names.user_id`.
+_Avoid_: Enum, constants class when the values are derived from ColumnDefinitions
+
+**Deprecated Field**:
+A field that remains in the FastDataFrameModel and backend schema but is marked as discouraged for new use. Deprecated Fields must be nullable and remain available through name accessors while they are still model fields.
+_Avoid_: Removed column when the field is still present in the model
+
+**Deprecated Column Name**:
+A column name that has been removed from the FastDataFrameModel but remains reserved to prevent reuse and protect existing consumers. It is not part of generated canonical schemas and is not physically deleted by default.
+_Avoid_: Deprecated Field when the field is no longer present in the model
+
+**Removed Column Name**:
+A previously used column name that is eligible for explicit destructive deletion from a backend schema. Removed Column Names remain reserved and must not be reused.
+_Avoid_: Deprecated Column Name when physical deletion is intended
+
+**Backend Schema**:
+A schema object native to a dataframe or table backend, such as a Polars, PyArrow, or Iceberg schema.
+_Avoid_: Model schema when referring to backend-native schemas
+
+**Persistence Schema Boundary**:
+The PyArrow schema boundary used before writing dataframe data into Iceberg. Polars data destined for Iceberg is converted through the FastDataFrame-generated PyArrow schema because Polars schemas do not encode column nullability in the same way as PyArrow and Iceberg.
+_Avoid_: Polars schema as the final persistence contract for Iceberg writes
+
+**Backend Function**:
+A stateless function in a backend namespace that consumes a FastDataFrame model or ColumnDefinitions and returns a backend-specific result.
+_Avoid_: Backend adapter, backend service, backend model when no state is involved
+
+## Example dialogue
+
+Developer: “Should the Polars backend inspect the Pydantic field directly?”
+Domain expert: “No. The Pydantic Model is the declaration surface, but each backend should consume the normalized ColumnDefinition.”
+
+Developer: “Where do we put lakehouse metadata like deprecation or Iceberg field identity?”
+Domain expert: “That belongs in ColumnInfo, then becomes part of the derived ColumnDefinition.”

--- a/README.md
+++ b/README.md
@@ -1,152 +1,185 @@
 # FastDataFrame
 
-**FastDataFrame** is a modern Python library that bridges the world of [Pydantic](https://docs.pydantic.dev/) models and dataframe libraries, providing a standard interface for validating, transforming, and creating dataframes from Pydantic models. It currently supports:
+**FastDataFrame** bridges [Pydantic](https://docs.pydantic.dev/) models and dataframe/table backends. A FastDataFrame model owns backend-neutral column definitions, and backend modules expose stateless functions for Polars, PyArrow, and Apache Iceberg.
 
-- [Polars](https://www.pola.rs/) DataFrame and LazyFrame
-- [Apache Iceberg](https://iceberg.apache.org/) tables
+Supported backends:
 
-The goal is to make it easy to:
-- Validate a dataframe against a Pydantic model schema
-- Convert a dataframe to an iterable of Pydantic models
-- Create a dataframe from a list of Pydantic models, with correct types
+- [Polars](https://www.pola.rs/) `DataFrame` and `LazyFrame`
+- [PyArrow](https://arrow.apache.org/docs/python/) schemas
+- [Apache Iceberg](https://iceberg.apache.org/) schemas/tables through PyIceberg
 
----
+## Core idea
 
-## Features
-
-- **Schema Validation:** Ensure your dataframe matches your Pydantic model's schema.
-- **Model Conversion:** Easily convert between dataframes and Pydantic models.
-- **Type-Safe DataFrames:** Automatically infer and enforce correct column types.
-- **Multi-Backend:** Works with Polars and Iceberg (with plans for Pandas, PyArrow, and more).
-
----
-
-## Polars Integration
-
-### 1. Define Your Pydantic Model
+Define the schema once:
 
 ```python
-from pydantic import BaseModel
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from fastdataframe import ColumnInfo, FastDataFrameModel, Int32
+
 
 class User(BaseModel):
-    id: int
+    user_id: Annotated[
+        int,
+        Field(validation_alias="userId", serialization_alias="user_id"),
+        ColumnInfo(dtype=Int32()),
+    ]
     name: str
-    age: int
+    score: float = 0.0
+    nickname: str | None = None
+
+
+FastUser = FastDataFrameModel.from_base_model(User)
 ```
 
-### 2. Create a Polars DataFrame from Models
+Then generate backend-native schemas with stateless backend functions:
+
+```python
+import fastdataframe.polars as fpl
+import fastdataframe.pyarrow as farrow
+import fastdataframe.iceberg as fice
+
+polars_schema = fpl.schema(FastUser)
+arrow_schema = farrow.schema(FastUser)
+iceberg_schema = fice.schema(FastUser)
+```
+
+## Column definitions
+
+`FastDataFrameModel` owns immutable, backend-neutral column definitions:
+
+```python
+FastUser.column_definitions
+FastUser.column_map
+```
+
+`ColumnInfo` is optional user-authored metadata. Fields without `ColumnInfo` receive default metadata.
+
+```python
+class Trade(FastDataFrameModel):
+    trade_id: str
+    quantity: Annotated[int, ColumnInfo(dtype=Int32(), is_unique=False)]
+```
+
+## Name accessors
+
+Resolved names are available as immutable accessors keyed by Python field name:
+
+```python
+FastUser.serialization_names.user_id  # "user_id"
+FastUser.validation_names.user_id     # "userId"
+FastUser.storage_names.user_id        # "user_id"
+FastUser.serialization_names["user_id"]
+```
+
+The storage name is the canonical dataframe/table column name and defaults to the Pydantic serialization name.
+
+## Dtype refinements
+
+`ColumnInfo(dtype=...)` can refine backend schema generation while the Python annotation remains the semantic type.
+
+Initial backend-neutral scalar dtypes include:
+
+- `Boolean`, `String`, `Binary`
+- `Int8`, `Int16`, `Int32`, `Int64`
+- `Float32`, `Float64`
+- `Date`, `Time`, `Timestamp`
+- `Decimal`
+
+Unsigned integer dtypes are intentionally not included initially. Small signed integers are widened when mapped to Iceberg where necessary.
+
+## Polars
 
 ```python
 import polars as pl
-from fastdataframe.polars.model import PolarsFastDataframeModel
+import fastdataframe.polars as fpl
 
-# Create a Polars-compatible model
-PolarsUser = PolarsFastDataframeModel.from_base_model(User)
+raw = pl.DataFrame({"user_id": ["1"], "name": ["Alice"], "score": ["1.5"], "nickname": [None]})
 
-# List of Pydantic models
-users = [
-    User(id=1, name="Alice", age=30),
-    User(id=2, name="Bob", age=25),
-]
-
-# Create a DataFrame
-df = pl.DataFrame([user.model_dump() for user in users])
-
-# Cast DataFrame to match the model schema (enforces types)
-df = PolarsUser.cast_to_model_schema(df)
-print(df)
+cast_df = fpl.cast(FastUser, raw)
+errors = fpl.validate_schema(FastUser, cast_df)
 ```
 
-### 3. Validate a DataFrame Against the Model
+`fpl.string_schema(FastUser)` returns a schema with all columns as strings for ingest flows.
+
+## PyArrow
 
 ```python
-errors = PolarsUser.validate_schema(df)
-if errors:
-    print("Validation errors:", errors)
-else:
-    print("DataFrame is valid!")
+import fastdataframe.pyarrow as farrow
+
+schema = farrow.schema(FastUser)
+string_schema = farrow.string_schema(FastUser)
 ```
 
-### 4. Convert DataFrame Rows to Pydantic Models
+PyArrow schemas encode nullability from `Optional` / `None` unions. Pydantic defaults do not imply nullable storage.
+
+## Iceberg
 
 ```python
-models = [PolarsUser(**row) for row in df.to_dicts()]
-print(models)
+import fastdataframe.iceberg as fice
+
+schema = fice.schema(FastUser)
 ```
 
----
-
-## Iceberg Integration
-
-### 1. Define Your Pydantic Model
+Iceberg migration support is additive-only by default:
 
 ```python
-from pydantic import BaseModel
-
-class Transaction(BaseModel):
-    transaction_id: str
-    amount: float
-    timestamp: str
+fice.apply_additive_migration(FastUser, table)
 ```
 
-### 2. Generate Iceberg Schema from Model
+Destructive deletes are intentionally not automatic.
+
+For Polars-to-Iceberg persistence, data is written through the FastDataFrame-generated PyArrow schema boundary:
 
 ```python
-from fastdataframe.iceberg.model import IcebergFastDataframeModel
-
-IcebergTransaction = IcebergFastDataframeModel.from_base_model(Transaction)
-iceberg_schema = IcebergTransaction.get_iceberg_schema()
-print(iceberg_schema)
+fice.append_polars(FastUser, table, cast_df)
 ```
 
-### 3. Validate Iceberg Table Schema
+This is important because Polars schemas do not encode column nullability in the same way as PyArrow and Iceberg.
+
+## Column lifecycle
+
+Deprecated fields remain model fields, remain in schemas, and must be nullable:
 
 ```python
-# Suppose you have an Iceberg table schema as a dict
-table_schema = {
-    "fields": [
-        {"name": "transaction_id", "type": "string"},
-        {"name": "amount", "type": "double"},
-        {"name": "timestamp", "type": "string"},
-    ]
-}
-
-errors = IcebergTransaction.validate_schema(table_schema)
-if errors:
-    print("Schema validation errors:", errors)
-else:
-    print("Iceberg schema is valid!")
+class UserV2(FastDataFrameModel):
+    old_score: Annotated[float | None, ColumnInfo(deprecated=True)]
+    score: float
 ```
 
----
+Deprecated and removed column names can be reserved through model config to prevent unsafe reuse:
 
-## Why FastDataFrame?
+```python
+class UserV3(FastDataFrameModel):
+    model_config = {
+        "fastdataframe_deprecated_column_names": {"old_score"},
+        "fastdataframe_removed_column_names": {"very_old_score"},
+    }
 
-- **Type Safety:** Enforce your data contracts at the dataframe level.
-- **Consistency:** Use the same Pydantic models for both API and data processing.
-- **Extensible:** Designed to support multiple dataframe backends.
+    score: float
+```
 
----
+Removed names remain reserved even if a backend later physically deletes the column.
 
 ## Installation
 
 ```bash
-uv pip install fastdataframe
-# or
 pip install fastdataframe
+# or with optional backends
+pip install 'fastdataframe[polars,pyarrow,iceberg]'
 ```
 
----
+## Development
 
-## Roadmap
-
-- [x] Polars support
-- [x] Iceberg support
-- [ ] Pandas support
-- [ ] PyArrow support
-- [ ] PyIceberg support
-
----
+```bash
+uv sync --all-extras
+uv run pytest tests/
+uv run ruff check .
+uv run ruff format .
+uv run ty check
+```
 
 ## License
 

--- a/docs/prd-fastdataframe-rewrite.md
+++ b/docs/prd-fastdataframe-rewrite.md
@@ -1,0 +1,249 @@
+# PRD: FastDataFrame Core Rewrite
+
+## Problem Statement
+
+FastDataFrame currently bridges Pydantic models to dataframe and lakehouse backends, but the core schema concept is not explicit enough for a full multi-backend design. Backend implementations read raw Pydantic field information directly, duplicate alias/nullability/type logic, and sometimes leak backend-native type concepts into model declarations. This makes it hard to provide a stable API across Polars, PyArrow, and Iceberg, especially for schema validation, Iceberg schema evolution, column lifecycle management, and Polars-to-Iceberg persistence.
+
+Users need a rewrite that makes the Pydantic model declaration the source of truth while introducing a backend-neutral normalized column layer. That layer must support optional column metadata, portable dtype refinements, name accessors, schema validation, and backend-specific functional APIs without coupling the core package to every backend implementation detail.
+
+## Solution
+
+Rewrite FastDataFrame around a backend-neutral `FastDataFrameModel` that owns immutable `ColumnDefinition` objects, analogous to how Pydantic `BaseModel` owns `model_fields`.
+
+Users will define schemas either by subclassing `FastDataFrameModel` directly or by generating one from a plain Pydantic `BaseModel` using `FastDataFrameModel.from_base_model()`. During this model layer, FastDataFrame derives `ColumnDefinition`s from Pydantic fields and optional `ColumnInfo` metadata.
+
+Backend modules will expose stateless functional APIs. For example, Polars support should be exposed through functions such as `fastdataframe.polars.schema(model)`, rather than backend-specific model subclasses. Backend functions consume `ColumnDefinition`s, not raw Pydantic fields.
+
+The rewrite introduces:
+
+- a clear separation between `ColumnInfo` and `ColumnDefinition`
+- read-only class-owned column metadata on `FastDataFrameModel`
+- read-only name accessors such as `User.serialization_names.user_id`
+- a backend-neutral scalar dtype system
+- canonical full-schema validation first
+- additive-only Iceberg schema migration on day one
+- explicit lifecycle support for deprecated and removed columns
+- a PyArrow persistence schema boundary for Polars-to-Iceberg writes
+
+## User Stories
+
+1. As a data engineer, I want to define a dataframe schema once using a Pydantic model, so that I can generate backend schemas consistently.
+2. As a data engineer, I want to convert a plain Pydantic `BaseModel` into a `FastDataFrameModel`, so that existing domain models can be reused for dataframe schemas.
+3. As a library user, I want `from_base_model()` to create a new FastDataFrame model class, so that the original Pydantic model is not mutated.
+4. As a library user, I want `from_base_model()` to preserve schema-relevant field information, so that aliases, defaults, annotations, constraints, and column metadata remain available.
+5. As a library user, I want `from_base_model()` to be schema-only initially, so that the conversion contract is predictable and not tied to preserving every Pydantic runtime behavior.
+6. As a future maintainer, I want Pydantic validator extraction to be treated as a later feature, so that dataframe value validation can be designed separately from schema generation.
+7. As a backend implementer, I want every backend to consume `ColumnDefinition`s instead of raw Pydantic `FieldInfo`, so that backend code is simpler and consistent.
+8. As a backend implementer, I want `ColumnDefinition` to be backend-neutral, so that it does not contain Polars, PyArrow, or Iceberg native types.
+9. As a schema author, I want `ColumnInfo` to be optional, so that ordinary Pydantic fields work without boilerplate.
+10. As a schema author, I want `ColumnInfo` to store only user-authored dataframe/lakehouse intent, so that it is not confused with resolved column definitions.
+11. As a schema author, I want to declare a backend-neutral `dtype` in `ColumnInfo`, so that I can refine physical/logical representation without importing Polars or PyArrow types into core declarations.
+12. As a schema author, I want `dtype` compatibility checked against the Python annotation, so that the Pydantic type remains the semantic type.
+13. As a schema author, I want string raw input casting to be handled by backend functions, so that `str` annotations are not misused to represent timestamps or dates.
+14. As a schema author, I want signed small integer dtypes supported, so that Polars and PyArrow schemas can use narrower integer widths.
+15. As an Iceberg user, I accept small signed integers widening to Iceberg `int`, so that the core dtype set remains useful across backends.
+16. As a schema author, I do not need unsigned integers on day one, so that the first dtype system avoids lossy unsigned semantics in Iceberg.
+17. As a schema author, I want scalar dtype refinements first, so that containers can continue to be expressed by Python annotations.
+18. As a schema author, I want list and struct shapes derived from Python/Pydantic annotations, so that I do not need to duplicate nested schema structure in a dtype DSL.
+19. As a developer, I want read-only `column_definitions`, so that schema metadata cannot be accidentally mutated.
+20. As a developer, I want read-only `column_map`, so that I can look up column definitions by canonical name.
+21. As a developer, I want column definitions built lazily by default, so that class creation remains robust with Pydantic model lifecycle behavior.
+22. As a developer, I want an eager validation option, so that applications can fail early at import/startup if ColumnDefinitions are invalid.
+23. As a developer, I want eager mode to validate only backend-neutral ColumnDefinitions, so that optional backend dependencies are not required for core validation.
+24. As a developer, I want `User.serialization_names.user_id` to return the resolved serialization name, so that column references are centralized and typo-resistant.
+25. As a developer, I want `User.validation_names.user_id` to return the resolved validation name, so that ingest and validation flows can reference aliases consistently.
+26. As a developer, I want name accessors keyed by Python field name, so that aliases remain values rather than attribute names.
+27. As a developer, I want name accessors to support item access as well as attribute access, so that dynamic or unusual model fields can still be addressed.
+28. As a developer, I want name accessors to be immutable at runtime, so that generated names remain stable.
+29. As a typing-focused user, I want the name accessor design to allow future generated stubs or `Literal` typing, so that stronger static typing can be added later.
+30. As a Polars user, I want a stateless function to generate a Polars schema, so that I do not need a backend-specific model subclass.
+31. As a Polars user, I want a stateless function to cast a DataFrame or LazyFrame according to a FastDataFrame model, so that raw data can be normalized before validation or persistence.
+32. As a Polars user, I want schema validation to compare column names and dtypes, so that incompatible frames are caught early.
+33. As a PyArrow user, I want a stateless function to generate a PyArrow schema, so that Arrow tables and Parquet workflows can share the same model contract.
+34. As a PyArrow user, I want nullability encoded in the PyArrow schema, so that persistence formats can enforce required and nullable columns.
+35. As an Iceberg user, I want a stateless function to generate an Iceberg schema, so that table creation can use the same model contract.
+36. As an Iceberg user, I want optional `iceberg_id` metadata, so that field identity can be introduced without requiring IDs for every day-one model.
+37. As an Iceberg user, I want additive-only migration on day one, so that schema evolution does not break existing consumers.
+38. As an Iceberg user, I want destructive column deletion to be explicit, so that removed columns are not deleted accidentally.
+39. As an Iceberg user, I want deprecated column names to remain reserved, so that old column names cannot be reused with new meanings.
+40. As an Iceberg user, I want removed column names to remain reserved even after physical deletion, so that schema history remains safe.
+41. As a schema author, I want deprecated fields to be nullable, so that producers are not forced to keep supplying meaningful values for discouraged fields.
+42. As a schema author, I want deprecated fields to remain in name accessors while they are still fields, so that existing code can still reference them during migration.
+43. As a schema author, I want hard-removed columns declared in model config, so that fields can be removed from the model while preserving lifecycle intent.
+44. As a schema author, I want Pydantic defaults and dataframe column presence treated separately, so that every model field remains a canonical dataframe column.
+45. As a schema author, I want nullability derived from `Optional` / `None` unions, so that default values do not incorrectly imply nullable storage.
+46. As a schema validator user, I want initial schema validation to validate the canonical full schema, so that missing model columns are treated as schema errors.
+47. As an ingestion pipeline author, I want permissive ingest validation deferred, so that canonical schema behavior is implemented clearly first.
+48. As a lakehouse pipeline author, I want Polars-to-Iceberg writes to pass through a FastDataFrame PyArrow schema, so that nullability and storage schema constraints are enforced before Iceberg persistence.
+49. As a lakehouse pipeline author, I want Polars schemas not to be treated as the final persistence contract, so that Polars’ lack of schema-level nullability does not hide Iceberg write errors.
+50. As a maintainer, I want backend modules to be stateless function namespaces, so that APIs are easy to test and reason about.
+51. As a maintainer, I want optional backend dependencies isolated to backend modules, so that core schema extraction does not require Polars, PyArrow, or PyIceberg.
+52. As a maintainer, I want a clear out-of-scope list, so that the rewrite does not become a full dataframe validation framework in one step.
+
+## Implementation Decisions
+
+### Core model and column metadata
+
+- `FastDataFrameModel` is the canonical model base for FastDataFrame schemas.
+- `FastDataFrameModel.from_base_model()` creates a new backend-neutral FastDataFrame model class from a Pydantic `BaseModel`.
+- The generated class should be named using the original model name plus a FastDataFrame suffix.
+- `from_base_model()` is schema-only for the initial rewrite. It preserves schema-relevant field declarations but does not promise to preserve all validators, methods, computed fields, serializers, or private attributes.
+- Pydantic validator extraction for dataframe value validation is a future design track.
+- `ColumnInfo` is optional metadata attached to Pydantic fields.
+- `ColumnDefinition` is created and owned by `FastDataFrameModel`, not by backend modules.
+- `ColumnDefinition` is immutable and backend-neutral.
+- Backend functions consume `ColumnDefinition`s instead of raw Pydantic field information.
+- `ColumnDefinition` contains resolved names, Python/Pydantic type information, nullability, requiredness, defaults, constraints, and `ColumnInfo`.
+- `ColumnDefinition` must not contain backend-native Polars, PyArrow, or Iceberg types.
+
+### ColumnDefinition lifecycle
+
+- `column_definitions` is exposed as a read-only class-owned property.
+- `column_map` is exposed as a read-only class-owned property.
+- ColumnDefinitions are built lazily by default.
+- Eager mode is opt-in.
+- Eager mode validates only backend-neutral ColumnDefinitions and does not require backend packages.
+- Invalid ColumnDefinitions should fail clearly when built lazily or eagerly.
+
+### Name accessors
+
+- FastDataFrame models expose name accessors derived from ColumnDefinitions.
+- Required accessors include serialization names and validation names.
+- Storage names should also be represented, with storage name defaulting to serialization name.
+- Accessors are keyed by Python field name.
+- Accessors support attribute access for normal Python field names.
+- Accessors support item access for all fields.
+- Accessors are immutable at runtime.
+- Initial typing may return `str`; the design should not block future generated stubs or `Literal` return types.
+- Name accessors exist only on `FastDataFrameModel` classes, including those generated by `from_base_model()`.
+
+### Column naming
+
+- The canonical dataframe/table column name is the storage name.
+- The storage name defaults to Pydantic’s serialization name.
+- Validation names remain available for ingest/validation workflows.
+- Python field names remain the stable developer-facing handles.
+
+### Dtype system
+
+- `ColumnInfo` includes an optional `dtype` field.
+- `dtype` is a backend-neutral scalar logical type refinement.
+- `dtype` must be compatible with the Python annotation.
+- Python annotations remain the semantic validation type.
+- Backend functions map `dtype` first and fall back to Python annotations when no dtype is declared.
+- Initial dtypes are scalar refinements only.
+- Container shapes are derived from Python/Pydantic annotations.
+- Initial dtype coverage includes booleans, strings, binary data, signed integers, floats, dates, times, timestamps, and decimals.
+- Signed small integers are supported in the core dtype set.
+- Iceberg may widen small signed integers to its available integer type.
+- Unsigned integers are out of scope initially.
+- Backend-native dtypes are not part of core `ColumnInfo`.
+
+### Nullability, requiredness, and column presence
+
+- Column presence and Pydantic required input are separate concepts.
+- Every model field is a canonical dataframe/table column by default, regardless of Pydantic defaults.
+- Nullability is derived from `Optional` / `None` union types.
+- Defaults do not make a column nullable.
+- Initial schema validation validates the canonical full schema.
+- Permissive ingest validation for missing defaultable/nullable fields is deferred.
+
+### Backend API shape
+
+- Backend modules expose stateless functions.
+- Backend-specific model subclasses are not the primary API.
+- Core remains backend-neutral.
+- Optional backend dependencies remain isolated to backend modules.
+- Polars support should expose schema generation, string schema generation, schema validation, and casting functions.
+- PyArrow support should expose schema generation and string schema generation.
+- Iceberg support should expose schema generation and additive-only migration functions.
+
+### Schema validation
+
+- Initial validation scope is schema validation only.
+- Schema validation does not apply Pydantic field/model validators.
+- Schema validation validates the canonical full dataframe/table schema.
+- Polars schema validation can validate names and dtypes but cannot prove schema-level nullability.
+- PyArrow and Iceberg schema validation can include nullability.
+
+### Column lifecycle
+
+- Active fields are normal model fields included in generated schemas.
+- Deprecated fields remain model fields and remain in generated schemas.
+- Deprecated fields must be nullable.
+- Deprecated fields remain available through name accessors.
+- Deprecated column names are removed from the model but reserved in model config.
+- Deprecated column names are not included in generated canonical schemas.
+- Deprecated column names are not physically deleted by default.
+- Removed column names are eligible for explicit destructive deletion from backends.
+- Removed column names remain reserved and must not be reused.
+
+### Iceberg schema evolution
+
+- Day-one Iceberg migration is additive-only.
+- Additive migration can create or add missing columns but should not rename or delete columns automatically.
+- Destructive deletion must be an explicit operation.
+- `ColumnInfo` includes optional Iceberg field identity metadata.
+- Iceberg field identity is optional day one.
+- If explicit field identity is present, Iceberg schema generation should use it.
+- If explicit field identity is absent, schema generation may assign deterministic IDs for new schema objects.
+- Strict field-ID modes can be added later.
+- The design is informed by the additive-only schema evolution pattern used in the Hawk codebase.
+
+### Polars-to-Iceberg persistence
+
+- Polars schemas are not the final persistence contract for Iceberg writes because they do not encode nullability like PyArrow/Iceberg.
+- Any Polars-to-Iceberg write helper should pass through the FastDataFrame-generated PyArrow schema.
+- The persistence flow should be: Polars DataFrame -> FastDataFrame Polars normalization -> PyArrow Table cast to FastDataFrame PyArrow schema -> Iceberg write.
+- Data-level null checks for non-nullable columns must happen before or during the PyArrow/Iceberg persistence boundary.
+
+## Testing Decisions
+
+- Tests should focus on public behavior rather than implementation details.
+- Core tests should verify that `FastDataFrameModel` owns immutable ColumnDefinitions.
+- Core tests should verify `from_base_model()` schema-only conversion behavior.
+- Core tests should verify optional `ColumnInfo` defaulting.
+- Core tests should verify dtype compatibility with Python annotations.
+- Core tests should verify nullable/default/required distinctions.
+- Core tests should verify deprecated field and reserved/removed column rules.
+- Core tests should verify name accessors using both attribute and item access.
+- Polars tests should verify schema generation from ColumnDefinitions.
+- Polars tests should verify string schema generation.
+- Polars tests should verify casting behavior for supported scalar types.
+- Polars tests should verify schema validation against the canonical full schema.
+- PyArrow tests should verify schema generation including nullability.
+- PyArrow tests should verify scalar dtype mappings.
+- PyArrow tests should verify schemas used as the persistence boundary.
+- Iceberg tests should verify schema generation from ColumnDefinitions.
+- Iceberg tests should verify signed integer widening behavior.
+- Iceberg tests should verify optional field identity handling.
+- Iceberg tests should verify additive-only migration planning/apply behavior.
+- Iceberg tests should verify deprecated/removed column lifecycle behavior.
+- End-to-end tests should verify Pydantic/FastDataFrame -> Polars -> PyArrow -> Iceberg flows.
+- Existing tests in `tests/core`, `tests/polars`, `tests/pyarrow`, `tests/iceberg`, and `tests/e2e` provide prior art and should be reorganized or rewritten around the new public APIs.
+- Compatibility tests should ensure backend modules do not read raw Pydantic field metadata directly where ColumnDefinitions are available.
+
+## Out of Scope
+
+- Applying Pydantic field/model validators to dataframe values.
+- Full row-level or cell-level dataframe validation using Pydantic validators.
+- Generated `.pyi` stubs or static `Literal` typing for name accessors.
+- Type-checker plugins.
+- Unsigned integer dtypes.
+- Backend-specific dtype extensions.
+- A full dtype DSL for containers.
+- Permissive ingest schema validation mode.
+- Automatic destructive Iceberg migrations.
+- Automatic column renames in Iceberg.
+- Guaranteeing exact round-trip preservation of small integer dtype through Iceberg schema introspection.
+- Preserving all behavioral aspects of source Pydantic models in `from_base_model()`.
+
+## Further Notes
+
+- The rewrite should keep core concepts precise:
+  - `ColumnInfo` is user-authored metadata.
+  - `ColumnDefinition` is resolved backend-neutral schema state owned by `FastDataFrameModel`.
+  - backend schemas are native schema objects produced from ColumnDefinitions.
+- The glossary in `CONTEXT.md` should remain synchronized with implementation decisions as the rewrite proceeds.
+- If Iceberg schema evolution behavior becomes more sophisticated than additive-only, an ADR should likely be created because it is hard to reverse, surprising without context, and involves real trade-offs.
+- If Pydantic validator extraction becomes part of a later milestone, it should receive its own PRD or design document because it introduces performance, semantics, and error-reporting questions beyond schema translation.

--- a/src/fastdataframe/__init__.py
+++ b/src/fastdataframe/__init__.py
@@ -1,7 +1,44 @@
-"""FastDataframe - A fast dataframe implementation with Pydantic integration."""
+"""FastDataFrame - Pydantic-powered dataframe schemas."""
 
 from fastdataframe.core.annotation import ColumnInfo
-from fastdataframe.core.model import FastDataframeModel
+from fastdataframe.core.column import ColumnDefinition, NameAccessor
+from fastdataframe.core.dtypes import (
+    Binary,
+    Boolean,
+    Date,
+    Decimal,
+    Dtype,
+    Float32,
+    Float64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Time,
+    Timestamp,
+)
+from fastdataframe.core.model import FastDataFrameModel, FastDataframeModel
 
 __version__ = "0.1.0"
-__all__ = ["ColumnInfo", "FastDataframeModel"]
+__all__ = [
+    "Binary",
+    "Boolean",
+    "ColumnDefinition",
+    "ColumnInfo",
+    "Date",
+    "Decimal",
+    "Dtype",
+    "FastDataFrameModel",
+    "FastDataframeModel",
+    "Float32",
+    "Float64",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "NameAccessor",
+    "String",
+    "Time",
+    "Timestamp",
+]

--- a/src/fastdataframe/core/annotation.py
+++ b/src/fastdataframe/core/annotation.py
@@ -2,8 +2,11 @@
 
 from dataclasses import dataclass
 from typing import Any, Self, cast
-from pydantic._internal._fields import PydanticMetadata
+
 from annotated_types import BaseMetadata
+from pydantic._internal._fields import PydanticMetadata
+
+from fastdataframe.core.dtypes import Dtype
 
 
 @dataclass(frozen=True)
@@ -21,6 +24,9 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
     bool_true_string: str = "true"
     bool_false_string: str = "false"
     date_format: str = "%Y-%m-%d"
+    dtype: Dtype | None = None
+    deprecated: bool = False
+    iceberg_id: int | None = None
 
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Any
@@ -42,6 +48,7 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
         # Add both the properties and a reconstruction document
         schema["json_schema_extra"] = {
             "is_unique": self.is_unique,
+            "deprecated": self.deprecated,
             # Add a document that can be used to reconstruct the FastDataframe
             "_fastdataframe": {
                 "type": "FastDataframe",
@@ -135,4 +142,5 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
                 },
             },
             "is_unique": self.is_unique,
+            "deprecated": self.deprecated,
         }

--- a/src/fastdataframe/core/annotation.py
+++ b/src/fastdataframe/core/annotation.py
@@ -6,6 +6,7 @@ from typing import Any, Self, cast
 from annotated_types import BaseMetadata
 from pydantic._internal._fields import PydanticMetadata
 
+from fastdataframe.core import dtypes as fdt
 from fastdataframe.core.dtypes import Dtype
 
 
@@ -28,6 +29,64 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
     deprecated: bool = False
     iceberg_id: int | None = None
 
+    def _dtype_metadata(self) -> dict[str, Any] | None:
+        if self.dtype is None:
+            return None
+        metadata: dict[str, Any] = {"name": type(self.dtype).__name__}
+        if isinstance(self.dtype, fdt.Decimal):
+            metadata.update(
+                {"precision": self.dtype.precision, "scale": self.dtype.scale}
+            )
+        elif isinstance(self.dtype, fdt.Timestamp):
+            metadata.update({"timezone": self.dtype.timezone})
+        return metadata
+
+    @staticmethod
+    def _dtype_from_metadata(metadata: Any) -> Dtype | None:
+        if metadata is None:
+            return None
+        if isinstance(metadata, Dtype):
+            return metadata
+        if not isinstance(metadata, dict):
+            raise ValueError("Invalid dtype metadata")
+        name = metadata.get("name")
+        dtype_classes: dict[str, type[Dtype]] = {
+            "Boolean": fdt.Boolean,
+            "String": fdt.String,
+            "Binary": fdt.Binary,
+            "Int8": fdt.Int8,
+            "Int16": fdt.Int16,
+            "Int32": fdt.Int32,
+            "Int64": fdt.Int64,
+            "Float32": fdt.Float32,
+            "Float64": fdt.Float64,
+            "Date": fdt.Date,
+            "Time": fdt.Time,
+            "Timestamp": fdt.Timestamp,
+            "Decimal": fdt.Decimal,
+        }
+        dtype_cls = dtype_classes.get(name)
+        if dtype_cls is None:
+            raise ValueError(f"Unknown dtype metadata: {name}")
+        if dtype_cls is fdt.Decimal:
+            return fdt.Decimal(
+                precision=int(metadata["precision"]), scale=int(metadata["scale"])
+            )
+        if dtype_cls is fdt.Timestamp:
+            return fdt.Timestamp(timezone=metadata.get("timezone"))
+        return dtype_cls()
+
+    def _metadata_properties(self) -> dict[str, Any]:
+        return {
+            "is_unique": self.is_unique,
+            "bool_true_string": self.bool_true_string,
+            "bool_false_string": self.bool_false_string,
+            "date_format": self.date_format,
+            "dtype": self._dtype_metadata(),
+            "deprecated": self.deprecated,
+            "iceberg_id": self.iceberg_id,
+        }
+
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Any
     ) -> dict[str, Any]:
@@ -46,16 +105,14 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
         """
         schema = cast(dict[str, Any], handler(source_type))
         # Add both the properties and a reconstruction document
+        properties = self._metadata_properties()
         schema["json_schema_extra"] = {
-            "is_unique": self.is_unique,
-            "deprecated": self.deprecated,
+            **properties,
             # Add a document that can be used to reconstruct the FastDataframe
             "_fastdataframe": {
                 "type": "FastDataframe",
                 "version": "1.0",
-                "properties": {
-                    "is_unique": self.is_unique,
-                },
+                "properties": properties,
             },
         }
         return schema
@@ -129,18 +186,23 @@ class ColumnInfo(PydanticMetadata, BaseMetadata):
                 f"Missing required properties: {required_props - set(properties.keys())}"
             )
 
+        properties = dict(properties)
+        properties["dtype"] = cls._dtype_from_metadata(properties.get("dtype"))
         return cls(**properties)
+
+    @classmethod
+    def from_field_metadata(cls, metadata: dict[str, Any]) -> "ColumnInfo":
+        """Create a ColumnInfo from Field(json_schema_extra=...) metadata."""
+        return cls.from_schema({"json_schema_extra": metadata})
 
     def as_field_metadata(self) -> dict[str, Any]:
         """Return a dictionary suitable for use as Pydantic Field(json_schema_extra=...)."""
+        properties = self._metadata_properties()
         return {
             "_fastdataframe": {
                 "type": "FastDataframe",
                 "version": "1.0",
-                "properties": {
-                    "is_unique": self.is_unique,
-                },
+                "properties": properties,
             },
-            "is_unique": self.is_unique,
-            "deprecated": self.deprecated,
+            **properties,
         }

--- a/src/fastdataframe/core/column.py
+++ b/src/fastdataframe/core/column.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Iterator, Mapping
+from typing import Any, Iterator, Mapping, cast
 
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
@@ -78,6 +78,13 @@ def get_column_info(field_info: FieldInfo) -> ColumnInfo:
     for metadata in field_info.metadata:
         if isinstance(metadata, ColumnInfo):
             return metadata
+
+    json_schema_extra = field_info.json_schema_extra
+    if isinstance(json_schema_extra, ColumnInfo):
+        return json_schema_extra
+    if isinstance(json_schema_extra, dict) and "_fastdataframe" in json_schema_extra:
+        return ColumnInfo.from_field_metadata(cast(dict[str, Any], json_schema_extra))
+
     return ColumnInfo.from_field_type(field_info)
 
 

--- a/src/fastdataframe/core/column.py
+++ b/src/fastdataframe/core/column.py
@@ -1,0 +1,127 @@
+"""Column definitions and name accessors for FastDataFrame models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Iterator, Mapping
+
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from fastdataframe.core.annotation import ColumnInfo
+from fastdataframe.core.pydantic.field_info import (
+    get_serialization_alias,
+    get_validation_alias,
+)
+from fastdataframe.core.types_helper import is_optional_type
+
+
+@dataclass(frozen=True)
+class ColumnDefinition:
+    """Backend-neutral normalized representation of a dataframe column."""
+
+    python_name: str
+    validation_name: str
+    serialization_name: str
+    storage_name: str
+    annotation: Any
+    nullable: bool
+    required_input: bool
+    has_default: bool
+    default: Any
+    field_info: FieldInfo
+    info: ColumnInfo
+
+    @property
+    def deprecated(self) -> bool:
+        """Whether this field is still present but deprecated."""
+        return self.info.deprecated
+
+
+class NameAccessor(Mapping[str, str]):
+    """Immutable accessor for resolved column names.
+
+    Values are keyed by Python field name and available through both attribute and
+    item access where possible.
+    """
+
+    _names: Mapping[str, str]
+
+    def __init__(self, names: Mapping[str, str]) -> None:
+        object.__setattr__(self, "_names", MappingProxyType(dict(names)))
+
+    def __getitem__(self, key: str) -> str:
+        return self._names[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._names)
+
+    def __len__(self) -> int:
+        return len(self._names)
+
+    def __getattr__(self, name: str) -> str:
+        try:
+            return self._names[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: str) -> None:
+        raise AttributeError("NameAccessor is immutable")
+
+    def __repr__(self) -> str:
+        return f"NameAccessor({dict(self._names)!r})"
+
+
+def get_column_info(field_info: FieldInfo) -> ColumnInfo:
+    """Extract ColumnInfo metadata from a Pydantic field, or return defaults."""
+    for metadata in field_info.metadata:
+        if isinstance(metadata, ColumnInfo):
+            return metadata
+    return ColumnInfo.from_field_type(field_info)
+
+
+def build_column_definition(field_name: str, field_info: FieldInfo) -> ColumnDefinition:
+    """Build and validate one ColumnDefinition from a Pydantic field."""
+    column_info = get_column_info(field_info)
+    annotation = field_info.annotation
+    nullable = is_optional_type(annotation)
+    has_default = field_info.default is not PydanticUndefined
+    has_default_factory = field_info.default_factory is not None
+    required_input = not has_default and not has_default_factory
+
+    if column_info.deprecated and not nullable:
+        raise ValueError(f"Deprecated field '{field_name}' must be nullable")
+
+    if column_info.dtype is not None and not column_info.dtype.is_compatible_annotation(
+        annotation
+    ):
+        raise ValueError(
+            f"Column '{field_name}' dtype {column_info.dtype!r} is not compatible "
+            f"with annotation {annotation!r}"
+        )
+
+    serialization_name = get_serialization_alias(field_info, field_name)
+    validation_name = get_validation_alias(field_info, field_name)
+
+    return ColumnDefinition(
+        python_name=field_name,
+        validation_name=validation_name,
+        serialization_name=serialization_name,
+        storage_name=serialization_name,
+        annotation=annotation,
+        nullable=nullable,
+        required_input=required_input,
+        has_default=has_default or has_default_factory,
+        default=field_info.default,
+        field_info=field_info,
+        info=column_info,
+    )
+
+
+__all__ = [
+    "ColumnDefinition",
+    "NameAccessor",
+    "build_column_definition",
+    "get_column_info",
+]

--- a/src/fastdataframe/core/dtypes.py
+++ b/src/fastdataframe/core/dtypes.py
@@ -58,9 +58,8 @@ class Int64(Dtype):
     python_types: ClassVar[tuple[type[Any], ...]] = (int,)
 
 
-@dataclass(frozen=True)
-class Float32(Dtype):
-    python_types: ClassVar[tuple[type[Any], ...]] = (float,)
+class StrictFloatCompatibility:
+    """Mixin for dtypes that require strict float annotation identity."""
 
     def is_compatible_annotation(self, annotation: Any) -> bool:
         from fastdataframe.core.types_helper import unwrap_annotated_optional
@@ -70,14 +69,13 @@ class Float32(Dtype):
 
 
 @dataclass(frozen=True)
-class Float64(Dtype):
+class Float32(StrictFloatCompatibility, Dtype):
     python_types: ClassVar[tuple[type[Any], ...]] = (float,)
 
-    def is_compatible_annotation(self, annotation: Any) -> bool:
-        from fastdataframe.core.types_helper import unwrap_annotated_optional
 
-        annotation = unwrap_annotated_optional(annotation)
-        return annotation is float
+@dataclass(frozen=True)
+class Float64(StrictFloatCompatibility, Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (float,)
 
 
 @dataclass(frozen=True)

--- a/src/fastdataframe/core/dtypes.py
+++ b/src/fastdataframe/core/dtypes.py
@@ -1,0 +1,135 @@
+"""Backend-neutral dtype refinements for FastDataFrame columns."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal as PythonDecimal
+from typing import Any, ClassVar
+
+
+class Dtype:
+    """Base class for backend-neutral logical column type refinements."""
+
+    python_types: ClassVar[tuple[type[Any], ...]] = ()
+
+    def is_compatible_annotation(self, annotation: Any) -> bool:
+        """Return whether this dtype can refine the given Python annotation."""
+        from fastdataframe.core.types_helper import unwrap_annotated_optional
+
+        annotation = unwrap_annotated_optional(annotation)
+        return isinstance(annotation, type) and issubclass(
+            annotation, self.python_types
+        )
+
+
+@dataclass(frozen=True)
+class Boolean(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (bool,)
+
+
+@dataclass(frozen=True)
+class String(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (str,)
+
+
+@dataclass(frozen=True)
+class Binary(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (bytes,)
+
+
+@dataclass(frozen=True)
+class Int8(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (int,)
+
+
+@dataclass(frozen=True)
+class Int16(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (int,)
+
+
+@dataclass(frozen=True)
+class Int32(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (int,)
+
+
+@dataclass(frozen=True)
+class Int64(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (int,)
+
+
+@dataclass(frozen=True)
+class Float32(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (float,)
+
+    def is_compatible_annotation(self, annotation: Any) -> bool:
+        from fastdataframe.core.types_helper import unwrap_annotated_optional
+
+        annotation = unwrap_annotated_optional(annotation)
+        return annotation is float
+
+
+@dataclass(frozen=True)
+class Float64(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (float,)
+
+    def is_compatible_annotation(self, annotation: Any) -> bool:
+        from fastdataframe.core.types_helper import unwrap_annotated_optional
+
+        annotation = unwrap_annotated_optional(annotation)
+        return annotation is float
+
+
+@dataclass(frozen=True)
+class Date(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (dt.date,)
+
+    def is_compatible_annotation(self, annotation: Any) -> bool:
+        from fastdataframe.core.types_helper import unwrap_annotated_optional
+
+        annotation = unwrap_annotated_optional(annotation)
+        return annotation is dt.date
+
+
+@dataclass(frozen=True)
+class Time(Dtype):
+    python_types: ClassVar[tuple[type[Any], ...]] = (dt.time,)
+
+
+@dataclass(frozen=True)
+class Timestamp(Dtype):
+    timezone: str | None = None
+    python_types: ClassVar[tuple[type[Any], ...]] = (dt.datetime,)
+
+
+@dataclass(frozen=True)
+class Decimal(Dtype):
+    precision: int
+    scale: int
+    python_types: ClassVar[tuple[type[Any], ...]] = (PythonDecimal,)
+
+    def __post_init__(self) -> None:
+        if self.precision <= 0:
+            raise ValueError("Decimal precision must be greater than zero")
+        if self.scale < 0:
+            raise ValueError("Decimal scale must be greater than or equal to zero")
+        if self.scale > self.precision:
+            raise ValueError("Decimal scale must be less than or equal to precision")
+
+
+__all__ = [
+    "Binary",
+    "Boolean",
+    "Date",
+    "Decimal",
+    "Dtype",
+    "Float32",
+    "Float64",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "String",
+    "Time",
+    "Timestamp",
+]

--- a/src/fastdataframe/core/dtypes.py
+++ b/src/fastdataframe/core/dtypes.py
@@ -18,6 +18,8 @@ class Dtype:
         from fastdataframe.core.types_helper import unwrap_annotated_optional
 
         annotation = unwrap_annotated_optional(annotation)
+        if annotation is bool:
+            return bool in self.python_types
         return isinstance(annotation, type) and issubclass(
             annotation, self.python_types
         )

--- a/src/fastdataframe/core/model.py
+++ b/src/fastdataframe/core/model.py
@@ -1,10 +1,20 @@
-"""FastDataframe model implementation."""
+"""FastDataFrame model implementation."""
 
-from typing import Literal, Type, TypeVar
+from __future__ import annotations
 
-from pydantic import BaseModel, create_model
+from types import MappingProxyType
+from collections.abc import Callable
+from typing import Any, ClassVar, Generic, Literal, Mapping, Type, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict, create_model
 from pydantic.fields import FieldInfo
 
+from fastdataframe.core.column import (
+    ColumnDefinition,
+    NameAccessor,
+    build_column_definition,
+    get_column_info,
+)
 from fastdataframe.core.pydantic.field_info import (
     get_serialization_alias,
     get_validation_alias,
@@ -12,185 +22,225 @@ from fastdataframe.core.pydantic.field_info import (
 
 from .annotation import ColumnInfo
 
-T = TypeVar("T", bound="FastDataframeModel")
+T = TypeVar("T", bound="FastDataFrameModel")
 TBaseModel = TypeVar("TBaseModel", bound=BaseModel)
 AliasType = Literal["serialization", "validation"]
+NameType = Literal["storage", "serialization", "validation", "python"]
+
+
+TValue = TypeVar("TValue")
+
+
+class classproperty(Generic[TValue]):
+    """Read-only class-level property descriptor."""
+
+    def __init__(self, func: Callable[[type[Any]], TValue]) -> None:
+        self.func = func
+
+    def __get__(self, instance: object, owner: type | None = None) -> TValue:
+        if owner is None:
+            owner = type(instance)
+        return self.func(owner)
 
 
 def _get_column_info(field_info: FieldInfo) -> ColumnInfo:
-    for m in field_info.metadata:
-        if isinstance(m, ColumnInfo):
-            return m
-    return ColumnInfo.from_field_type(field_info)
+    """Backward-compatible helper for extracting ColumnInfo."""
+    return get_column_info(field_info)
 
 
-class FastDataframeModel(BaseModel):
-    """Base model that enforces FastDataframe annotation on all fields."""
+class FastDataFrameModel(BaseModel):
+    """Base model that owns FastDataFrame column definitions."""
+
+    model_config = ConfigDict(ignored_types=(classproperty,))
+
+    __fastdataframe_column_definitions__: ClassVar[
+        tuple[ColumnDefinition, ...] | None
+    ] = None
+    __fastdataframe_column_map__: ClassVar[Mapping[str, ColumnDefinition] | None] = None
+    __fastdataframe_serialization_names__: ClassVar[NameAccessor | None] = None
+    __fastdataframe_validation_names__: ClassVar[NameAccessor | None] = None
+    __fastdataframe_storage_names__: ClassVar[NameAccessor | None] = None
+    __fastdataframe_python_names__: ClassVar[NameAccessor | None] = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        eager_columns = bool(kwargs.pop("eager_columns", False))
+        super().__init_subclass__(**kwargs)
+        cls._clear_fastdataframe_cache()
+        config_eager = bool(
+            getattr(cls, "model_config", {}).get("fastdataframe_eager_columns", False)
+        )
+        if eager_columns or config_eager:
+            cls._build_column_definitions()
+
+    @classmethod
+    def model_rebuild(cls, *args: Any, **kwargs: Any) -> bool | None:
+        """Rebuild the Pydantic model and clear derived FastDataFrame metadata."""
+        result = super().model_rebuild(*args, **kwargs)
+        cls._clear_fastdataframe_cache()
+        return result
+
+    @classmethod
+    def _clear_fastdataframe_cache(cls) -> None:
+        cls.__fastdataframe_column_definitions__ = None
+        cls.__fastdataframe_column_map__ = None
+        cls.__fastdataframe_serialization_names__ = None
+        cls.__fastdataframe_validation_names__ = None
+        cls.__fastdataframe_storage_names__ = None
+        cls.__fastdataframe_python_names__ = None
+
+    @classmethod
+    def _configured_names(cls, key: str) -> frozenset[str]:
+        raw_value = getattr(cls, "model_config", {}).get(key, frozenset())
+        return frozenset(raw_value or frozenset())
+
+    @classmethod
+    def deprecated_column_names(cls) -> frozenset[str]:
+        """Column names removed from the model but reserved from reuse."""
+        return cls._configured_names("fastdataframe_deprecated_column_names")
+
+    @classmethod
+    def removed_column_names(cls) -> frozenset[str]:
+        """Column names eligible for explicit destructive backend deletion."""
+        return cls._configured_names("fastdataframe_removed_column_names")
+
+    @classmethod
+    def _build_column_definitions(cls) -> tuple[ColumnDefinition, ...]:
+        columns = tuple(
+            build_column_definition(field_name, field_info)
+            for field_name, field_info in cls.model_fields.items()
+        )
+
+        seen_storage_names: set[str] = set()
+        for column in columns:
+            if column.storage_name in seen_storage_names:
+                raise ValueError(
+                    f"Duplicate storage column name: {column.storage_name}"
+                )
+            seen_storage_names.add(column.storage_name)
+
+        reserved_names = cls.deprecated_column_names() | cls.removed_column_names()
+        reused_reserved = seen_storage_names & reserved_names
+        if reused_reserved:
+            names = ", ".join(sorted(reused_reserved))
+            raise ValueError(f"Reserved column names cannot be reused: {names}")
+
+        column_map = {column.storage_name: column for column in columns}
+        cls.__fastdataframe_column_definitions__ = columns
+        cls.__fastdataframe_column_map__ = MappingProxyType(column_map)
+        cls.__fastdataframe_serialization_names__ = NameAccessor(
+            {column.python_name: column.serialization_name for column in columns}
+        )
+        cls.__fastdataframe_validation_names__ = NameAccessor(
+            {column.python_name: column.validation_name for column in columns}
+        )
+        cls.__fastdataframe_storage_names__ = NameAccessor(
+            {column.python_name: column.storage_name for column in columns}
+        )
+        cls.__fastdataframe_python_names__ = NameAccessor(
+            {column.python_name: column.python_name for column in columns}
+        )
+        return columns
+
+    @classproperty
+    def column_definitions(cls) -> tuple[ColumnDefinition, ...]:
+        """Ordered immutable ColumnDefinitions for this model."""
+        if cls.__fastdataframe_column_definitions__ is None:
+            return cls._build_column_definitions()
+        return cls.__fastdataframe_column_definitions__
+
+    @classproperty
+    def column_map(cls) -> Mapping[str, ColumnDefinition]:
+        """Read-only mapping from storage name to ColumnDefinition."""
+        if cls.__fastdataframe_column_map__ is None:
+            cls._build_column_definitions()
+        assert cls.__fastdataframe_column_map__ is not None
+        return cls.__fastdataframe_column_map__
+
+    @classproperty
+    def serialization_names(cls) -> NameAccessor:
+        """Resolved serialization names keyed by Python field name."""
+        if cls.__fastdataframe_serialization_names__ is None:
+            cls._build_column_definitions()
+        assert cls.__fastdataframe_serialization_names__ is not None
+        return cls.__fastdataframe_serialization_names__
+
+    @classproperty
+    def validation_names(cls) -> NameAccessor:
+        """Resolved validation names keyed by Python field name."""
+        if cls.__fastdataframe_validation_names__ is None:
+            cls._build_column_definitions()
+        assert cls.__fastdataframe_validation_names__ is not None
+        return cls.__fastdataframe_validation_names__
+
+    @classproperty
+    def storage_names(cls) -> NameAccessor:
+        """Resolved storage names keyed by Python field name."""
+        if cls.__fastdataframe_storage_names__ is None:
+            cls._build_column_definitions()
+        assert cls.__fastdataframe_storage_names__ is not None
+        return cls.__fastdataframe_storage_names__
+
+    @classproperty
+    def python_names(cls) -> NameAccessor:
+        """Python field names keyed by Python field name."""
+        if cls.__fastdataframe_python_names__ is None:
+            cls._build_column_definitions()
+        assert cls.__fastdataframe_python_names__ is not None
+        return cls.__fastdataframe_python_names__
 
     @classmethod
     def from_base_model(cls: Type[T], model: type[TBaseModel]) -> type[T]:
-        """Convert a Pydantic BaseModel to a FastDataframeModel subclass.
-
-        This method creates a new FastDataframeModel class that inherits from the calling class
-        and includes all the fields from the provided Pydantic model. This is useful for creating
-        dataframe-specific versions of existing Pydantic models while preserving their schema
-        and validation rules.
-
-        The method extracts field definitions from the source model and creates a new model
-        using Pydantic's `create_model` function. The new model will have the same field types,
-        validation rules, and metadata as the original model, but will also inherit the
-        FastDataframe-specific functionality from the calling class.
-
-        Args:
-            cls: The FastDataframeModel subclass to inherit from (e.g., PolarsFastDataframeModel)
-            model: A Pydantic BaseModel class to convert from
-
-        Returns:
-            A new FastDataframeModel subclass that combines the schema of the input model
-            with the functionality of the calling class.
-
-        Example:
-            ```python
-            from pydantic import BaseModel
-            from fastdataframe.polars.model import PolarsFastDataframeModel
-
-            # Define a base Pydantic model
-            class User(BaseModel):
-                id: int
-                name: str
-                age: int
-                is_active: bool = True
-
-            # Convert to a Polars-compatible model
-            PolarsUser = PolarsFastDataframeModel.from_base_model(User)
-
-            # The new model has all the original fields plus Polars functionality
-            assert issubclass(PolarsUser, PolarsFastDataframeModel)
-            assert PolarsUser.__name__ == "UserPolars"
-            assert "id" in PolarsUser.model_fields
-            assert "name" in PolarsUser.model_fields
-            assert "age" in PolarsUser.model_fields
-            assert "is_active" in PolarsUser.model_fields
-
-            # You can now use it with Polars dataframes
-            import polars as pl
-            df = pl.DataFrame({
-                "id": [1, 2, 3],
-                "name": ["Alice", "Bob", "Charlie"],
-                "age": [25, 30, 35],
-                "is_active": [True, False, True]
-            })
-
-            # Validate the dataframe against the model
-            errors = PolarsUser.validate_schema(df)
-            if not errors:
-                print("DataFrame is valid!")
-            ```
-
-        Notes:
-            - The new model's name will be "{original_model_name}{base_class_suffix}"
-              where the suffix is derived from the calling class name (e.g., "Polars" for PolarsFastDataframeModel)
-            - All field types, validation rules, and metadata from the original model are preserved
-            - The new model inherits all FastDataframe-specific methods from the calling class
-            - This method is commonly used to create dataframe-specific versions of existing Pydantic models
-            - The generated model maintains the same JSON schema as the original model
-        """
-
+        """Create a schema-only FastDataFrame model from a Pydantic model."""
         field_definitions = {
             field_name: (field_type.annotation, field_type)
             for field_name, field_type in model.model_fields.items()
         }
-        base_model_name = cls.__name__[: -len("FastDataframeModel")]
-        new_model: type[T] = create_model(
-            f"{model.__name__}{base_model_name}",
+        new_model = create_model(  # type: ignore[no-matching-overload]
+            f"{model.__name__}FastDataFrame",
             __base__=cls,
-            __doc__=f"{base_model_name} version of {model.__name__}",
+            __doc__=f"FastDataFrame version of {model.__name__}",
             **field_definitions,
-        )  # type: ignore[call-overload]
-        return new_model
+        )
+        return cast(type[T], new_model)
 
     @classmethod
     def model_columns(
         cls, alias_type: AliasType = "serialization"
     ) -> dict[str, ColumnInfo]:
-        """Extract column information from the model's fields with alias support.
-
-        This method returns a dictionary mapping column names (using the specified alias type)
-        to their corresponding ColumnInfo objects. It processes all fields in the model and
-        extracts their metadata, including any FastDataframe-specific annotations like
-        uniqueness constraints, boolean string mappings, and date formats.
-
-        The method supports two alias types:
-        - "serialization": Uses serialization aliases (default names for storage/export)
-        - "validation": Uses validation aliases (names used during data validation)
-
-        This is useful for:
-        - Understanding the schema of a model's columns
-        - Extracting metadata for dataframe operations
-        - Validating column configurations
-        - Building schema-aware data processing pipelines
-
-        Args:
-            alias_type: The type of alias to use for column names.
-                - "serialization": Use serialization aliases (default)
-                - "validation": Use validation aliases
-
-        Returns:
-            A dictionary mapping column names (using the specified alias) to ColumnInfo objects.
-            Each ColumnInfo contains metadata about the column including type information,
-            uniqueness constraints, and any custom FastDataframe annotations.
-
-        Example:
-            ```python
-            from fastdataframe import FastDataframeModel, ColumnInfo
-            from typing import Optional, Annotated
-
-            class UserModel(FastDataframeModel):
-                user_id: Annotated[int, ColumnInfo(is_unique=True)]
-                name: str
-                age: Optional[int] = None
-                is_active: Annotated[bool, ColumnInfo(
-                    bool_true_string="1",
-                    bool_false_string="0"
-                )]
-                birth_date: Annotated[str, ColumnInfo(date_format="%Y-%m-%d")]
-
-            # Get column information with serialization aliases
-            columns = UserModel.model_columns(alias_type="serialization")
-
-            # The result contains column names and their metadata
-            assert "user_id" in columns
-            assert columns["user_id"].is_unique is True
-            assert columns["is_active"].bool_true_string == "1"
-            assert columns["is_active"].bool_false_string == "0"
-            assert columns["birth_date"].date_format == "%Y-%m-%d"
-
-            # Get column information with validation aliases (if different)
-            validation_columns = UserModel.model_columns(alias_type="validation")
-
-            # Use the column information for dataframe operations
-            for column_name, column_info in columns.items():
-                print(f"Column: {column_name}")
-                print(f"  Is unique: {column_info.is_unique}")
-                print(f"  Date format: {column_info.date_format}")
-            ```
-
-        Notes:
-            - Column names are determined by the alias type specified
-            - Fields without explicit ColumnInfo annotations get default ColumnInfo objects
-            - The method processes all model fields, including inherited ones
-            - ColumnInfo objects contain metadata useful for dataframe operations
-            - This method is commonly used by dataframe-specific subclasses (Polars, Iceberg)
-            - The returned dictionary preserves the order of fields in the model
-        """
-
-        columns = {}
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
+        """Extract column information with backwards-compatible alias support."""
+        name_attr = (
+            "serialization_name" if alias_type == "serialization" else "validation_name"
         )
-        for field_name, field_info in cls.model_fields.items():
-            col_info = _get_column_info(field_info)
-            columns[alias_func(field_info, field_name)] = col_info
-        return columns
+        return {
+            getattr(column, name_attr): column.info for column in cls.column_definitions
+        }
+
+    @classmethod
+    def columns_by_name(
+        cls, name_type: NameType = "storage"
+    ) -> dict[str, ColumnDefinition]:
+        """Return ColumnDefinitions keyed by a selected resolved name."""
+        if name_type == "storage":
+            return {column.storage_name: column for column in cls.column_definitions}
+        if name_type == "serialization":
+            return {
+                column.serialization_name: column for column in cls.column_definitions
+            }
+        if name_type == "validation":
+            return {column.validation_name: column for column in cls.column_definitions}
+        return {column.python_name: column for column in cls.column_definitions}
+
+
+# Backwards-compatible spelling used by the existing package.
+FastDataframeModel = FastDataFrameModel
+
+
+__all__ = [
+    "AliasType",
+    "FastDataFrameModel",
+    "FastDataframeModel",
+    "NameType",
+    "_get_column_info",
+    "get_serialization_alias",
+    "get_validation_alias",
+]

--- a/src/fastdataframe/core/model.py
+++ b/src/fastdataframe/core/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, ClassVar, Generic, Literal, Mapping, Type, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, create_model
@@ -90,8 +90,15 @@ class FastDataFrameModel(BaseModel):
 
     @classmethod
     def _configured_names(cls, key: str) -> frozenset[str]:
-        raw_value = getattr(cls, "model_config", {}).get(key, frozenset())
-        return frozenset(raw_value or frozenset())
+        raw_value = getattr(cls, "model_config", {}).get(key, None)
+        if raw_value is None or isinstance(raw_value, str):
+            return frozenset()
+        if not isinstance(raw_value, Iterable):
+            return frozenset()
+        names = tuple(raw_value)
+        if not all(isinstance(name, str) for name in names):
+            return frozenset()
+        return frozenset(names)
 
     @classmethod
     def deprecated_column_names(cls) -> frozenset[str]:

--- a/src/fastdataframe/core/types_helper.py
+++ b/src/fastdataframe/core/types_helper.py
@@ -4,6 +4,31 @@ import types
 from typing import Any, Iterable, Optional, Type, get_origin, get_args, Annotated, Union
 
 
+def unwrap_annotated(annotation: Any) -> Any:
+    """Unwrap Annotated[T, ...] to T."""
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is Annotated and args:
+        return args[0]
+    return annotation
+
+
+def unwrap_annotated_optional(annotation: Any) -> Any:
+    """Unwrap Annotated and Optional/None unions to the non-None annotation.
+
+    If a union contains multiple non-None types, the original unwrapped annotation is
+    returned because there is no single semantic type to refine.
+    """
+    annotation = unwrap_annotated(annotation)
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin in (Union, types.UnionType):
+        non_none_args = [arg for arg in args if arg is not type(None)]
+        if len(non_none_args) == 1:
+            return unwrap_annotated(non_none_args[0])
+    return annotation
+
+
 def is_optional_type(field_type: Any) -> bool:
     """Check if a type is optional (can be None).
 

--- a/src/fastdataframe/iceberg/__init__.py
+++ b/src/fastdataframe/iceberg/__init__.py
@@ -1,1 +1,17 @@
-# This file marks the iceberg directory as a Python package.
+"""Iceberg integration for FastDataFrame."""
+
+from .model import (
+    IcebergFastDataframeModel,
+    append_polars,
+    apply_additive_migration,
+    schema,
+    validate_schema,
+)
+
+__all__ = [
+    "IcebergFastDataframeModel",
+    "append_polars",
+    "apply_additive_migration",
+    "schema",
+    "validate_schema",
+]

--- a/src/fastdataframe/iceberg/model.py
+++ b/src/fastdataframe/iceberg/model.py
@@ -1,54 +1,118 @@
-from fastdataframe.core.annotation import ColumnInfo
-from fastdataframe.core.json_schema import validate_missing_columns
-from fastdataframe.core.model import AliasType, FastDataframeModel, _get_column_info
-from fastdataframe.core.pydantic.field_info import (
-    get_serialization_alias,
-    get_validation_alias,
-)
-from fastdataframe.core.validation import ValidationError
-from typing import Any, List, get_args, get_origin, Annotated, Union
+"""Iceberg integration for FastDataFrame."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any, List, Union, cast, get_args, get_origin
+
+from pydantic import BaseModel
+from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.types import (
-    NestedField,
-    IntegerType,
+    BinaryType,
     BooleanType,
-    DoubleType,
-    IcebergType,
-    StringType,
     DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IcebergType,
+    IntegerType,
+    ListType,
+    LongType,
+    MapType,
+    NestedField,
+    StringType,
+    StructType,
     TimeType,
     TimestampType,
     UUIDType,
-    BinaryType,
-    ListType,
-    MapType,
-    StructType,
 )
-from pyiceberg.schema import Schema
-from fastdataframe.core.types_helper import is_optional_type
+
+from fastdataframe.core.annotation import ColumnInfo
+from fastdataframe.core.column import ColumnDefinition, get_column_info
+from fastdataframe.core.dtypes import (
+    Binary,
+    Boolean,
+    Date,
+    Decimal,
+    Float32,
+    Float64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Time,
+    Timestamp,
+)
+from fastdataframe.core.json_schema import validate_missing_columns
+from fastdataframe.core.model import AliasType, FastDataframeModel
+from fastdataframe.core.types_helper import is_optional_type, unwrap_annotated_optional
+from fastdataframe.core.validation import ValidationError
+
 from .json_schema import iceberg_schema_to_json_schema
 
 
-# Helper function to convert model fields to Iceberg NestedFields
+def _column_name(
+    column: ColumnDefinition, alias_type: AliasType = "serialization"
+) -> str:
+    if alias_type == "validation":
+        return column.validation_name
+    return column.storage_name
+
+
+def _dtype_to_iceberg_type(column_info: ColumnInfo) -> IcebergType | None:
+    dtype = column_info.dtype
+    if dtype is None:
+        return None
+    if isinstance(dtype, Boolean):
+        return BooleanType()
+    if isinstance(dtype, String):
+        return StringType()
+    if isinstance(dtype, Binary):
+        return BinaryType()
+    if isinstance(dtype, (Int8, Int16, Int32)):
+        return IntegerType()
+    if isinstance(dtype, Int64):
+        return LongType()
+    if isinstance(dtype, Float32):
+        return FloatType()
+    if isinstance(dtype, Float64):
+        return DoubleType()
+    if isinstance(dtype, Date):
+        return DateType()
+    if isinstance(dtype, Time):
+        return TimeType()
+    if isinstance(dtype, Timestamp):
+        return TimestampType()
+    if isinstance(dtype, Decimal):
+        return DecimalType(dtype.precision, dtype.scale)
+    return None
+
+
 def _model_fields_to_iceberg_fields(
-    model_fields: Any, alias_func: Any = None
+    model_fields: Any,
+    alias_func: Any = None,
+    start_field_id: int = 1,
 ) -> List[NestedField]:
     """Convert Pydantic model fields to Iceberg NestedField list."""
     fields = []
-    for idx, (field_name, field_info) in enumerate(model_fields.items(), 1):
+    for idx, (field_name, field_info) in enumerate(
+        model_fields.items(), start_field_id
+    ):
         py_type = field_info.annotation
-        column_info = _get_column_info(field_info)
+        column_info = get_column_info(field_info)
         nullable = is_optional_type(py_type)
         iceberg_type = _python_type_to_iceberg_type(
             py_type, field_id=idx, column_info=column_info
         )
         field_display_name = field_name
         if alias_func:
-            # Use alias function for root level fields (from __pydantic_fields__)
             field_display_name = alias_func(field_info, field_name)
         fields.append(
             NestedField(
-                field_id=idx,
+                field_id=column_info.iceberg_id or idx,
                 name=field_display_name,
                 field_type=iceberg_type,
                 required=not nullable,
@@ -57,23 +121,16 @@ def _model_fields_to_iceberg_fields(
     return fields
 
 
-# Helper function to map Python/Pydantic types to pyiceberg types
 def _python_type_to_iceberg_type(
     py_type: Any, field_id: int, column_info: ColumnInfo
 ) -> IcebergType:
-    # Unwrap Annotated to the underlying type
+    dtype_type = _dtype_to_iceberg_type(column_info)
+    if dtype_type is not None:
+        return dtype_type
+
+    py_type = unwrap_annotated_optional(py_type)
     origin = get_origin(py_type)
-    if origin is Annotated:
-        py_type = get_args(py_type)[0]
-        origin = get_origin(py_type)
 
-    # Unwrap Optional/Union[..., NoneType] for type mapping
-    if is_optional_type(py_type):
-        args = get_args(py_type)
-        py_type = next((a for a in args if a is not type(None)), None)
-        origin = get_origin(py_type)
-
-    # Primitive mappings
     if py_type is int:
         return IntegerType()
     if py_type is bool:
@@ -82,29 +139,23 @@ def _python_type_to_iceberg_type(
         return DoubleType()
     if py_type is str:
         return StringType()
-
-    import datetime
-    import uuid
-
-    if py_type is datetime.date:
+    if py_type is dt.date:
         return DateType()
-    if py_type is datetime.time:
+    if py_type is dt.time:
         return TimeType()
-    if py_type is datetime.datetime:
+    if py_type is dt.datetime:
         return TimestampType()
     if py_type is uuid.UUID:
         return UUIDType()
     if py_type is bytes:
         return BinaryType()
 
-    # List and sequence-like mappings
     if origin in (list, set, tuple):
         import types
 
         args = get_args(py_type)
         if args:
             element_annotation = args[0]
-            # Disallow unions with more than one non-None type for element types
             element_origin = get_origin(element_annotation)
             if element_origin in (Union, getattr(types, "UnionType", None)):
                 union_args = [
@@ -116,7 +167,7 @@ def _python_type_to_iceberg_type(
                     )
             element_required = not is_optional_type(element_annotation)
             element_type = _python_type_to_iceberg_type(
-                element_annotation, field_id=field_id, column_info=column_info
+                element_annotation, field_id=field_id, column_info=ColumnInfo()
             )
             return ListType(
                 element_id=field_id,
@@ -125,45 +176,33 @@ def _python_type_to_iceberg_type(
             )
         return ListType()
 
-    # Dictionary/Map mappings
     if origin is dict:
         import types
 
         args = get_args(py_type)
         if args and len(args) == 2:
             key_annotation, value_annotation = args
-
-            # Disallow unions with more than one non-None type for key types
-            key_origin = get_origin(key_annotation)
-            if key_origin in (Union, getattr(types, "UnionType", None)):
-                union_args = [
-                    a for a in get_args(key_annotation) if a is not type(None)
-                ]
-                if len(union_args) > 1:
-                    raise ValueError(
-                        "Map key types cannot be a union of multiple types; use a single type or Optional[T]."
-                    )
-
-            # Disallow unions with more than one non-None type for value types
-            value_origin = get_origin(value_annotation)
-            if value_origin in (Union, getattr(types, "UnionType", None)):
-                union_args = [
-                    a for a in get_args(value_annotation) if a is not type(None)
-                ]
-                if len(union_args) > 1:
-                    raise ValueError(
-                        "Map value types cannot be a union of multiple types; use a single type or Optional[T]."
-                    )
+            for annotation, label in (
+                (key_annotation, "Map key"),
+                (value_annotation, "Map value"),
+            ):
+                annotation_origin = get_origin(annotation)
+                if annotation_origin in (Union, getattr(types, "UnionType", None)):
+                    union_args = [
+                        a for a in get_args(annotation) if a is not type(None)
+                    ]
+                    if len(union_args) > 1:
+                        raise ValueError(
+                            f"{label} types cannot be a union of multiple types; use a single type or Optional[T]."
+                        )
 
             value_required = not is_optional_type(value_annotation)
-
             key_type = _python_type_to_iceberg_type(
-                key_annotation, field_id=field_id, column_info=column_info
+                key_annotation, field_id=field_id, column_info=ColumnInfo()
             )
             value_type = _python_type_to_iceberg_type(
-                value_annotation, field_id=field_id, column_info=column_info
+                value_annotation, field_id=field_id, column_info=ColumnInfo()
             )
-
             return MapType(
                 key_id=field_id,
                 key_type=key_type,
@@ -173,15 +212,94 @@ def _python_type_to_iceberg_type(
             )
         return MapType()
 
-    # BaseModel support - convert to StructType
-    from pydantic import BaseModel
-
     if isinstance(py_type, type) and issubclass(py_type, BaseModel):
         nested_fields = _model_fields_to_iceberg_fields(py_type.model_fields)
         return StructType(*nested_fields)
 
-    # Fallback to string for unsupported/unknown types
     return StringType()
+
+
+def _column_to_nested_field(
+    column: ColumnDefinition, idx: int, alias_type: AliasType
+) -> NestedField:
+    field_id = column.info.iceberg_id or idx
+    return NestedField(
+        field_id=field_id,
+        name=_column_name(column, alias_type),
+        field_type=_python_type_to_iceberg_type(
+            column.annotation,
+            field_id=field_id,
+            column_info=column.info,
+        ),
+        required=not column.nullable,
+    )
+
+
+def schema(
+    model: type[FastDataframeModel], alias_type: AliasType = "serialization"
+) -> Schema:
+    """Return a pyiceberg Schema based on a FastDataFrame model."""
+    fields = [
+        _column_to_nested_field(column, idx, alias_type)
+        for idx, column in enumerate(model.column_definitions, 1)
+    ]
+    return Schema(*fields)
+
+
+def validate_schema(
+    model: type[FastDataframeModel], table: Table, *, canonical: bool = True
+) -> List[ValidationError]:
+    """Validate that an Iceberg table contains the model's columns."""
+    table_json_schema = iceberg_schema_to_json_schema(table.schema())
+    model_json_schema = model.model_json_schema().copy()
+    if canonical:
+        storage_names = [column.storage_name for column in model.column_definitions]
+        model_json_schema["required"] = storage_names
+        if "properties" in model_json_schema:
+            model_json_schema["properties"] = {
+                column.storage_name: model_json_schema["properties"].get(
+                    column.python_name,
+                    model_json_schema["properties"].get(column.storage_name, {}),
+                )
+                for column in model.column_definitions
+            }
+    errors = validate_missing_columns(model_json_schema, table_json_schema)
+    return list(errors.values())
+
+
+def append_polars(
+    model: type[FastDataframeModel],
+    table: Table,
+    frame: Any,
+    alias_type: AliasType = "serialization",
+) -> None:
+    """Append a Polars frame to Iceberg through the FastDataFrame PyArrow schema.
+
+    Polars schemas do not encode nullability like PyArrow/Iceberg, so the Arrow
+    schema generated from the FastDataFrame model is the persistence boundary.
+    """
+    from fastdataframe.pyarrow.model import schema as pyarrow_schema
+    from fastdataframe.polars.model import cast as polars_cast
+
+    normalized = polars_cast(model, frame, alias_type)
+    collect = getattr(normalized, "collect", None)
+    if callable(collect):
+        normalized = collect()
+    normalized = cast(Any, normalized)
+    arrow_table = normalized.to_arrow().cast(pyarrow_schema(model, alias_type))
+    table.append(arrow_table)
+
+
+def apply_additive_migration(
+    model: type[FastDataframeModel],
+    table: Table,
+    alias_type: AliasType = "serialization",
+) -> Table:
+    """Apply additive-only schema evolution to an Iceberg table."""
+    new_schema = schema(model, alias_type)
+    with table.transaction() as txn, txn.update_schema() as update:
+        update.union_by_name(new_schema)
+    return table
 
 
 class IcebergFastDataframeModel(FastDataframeModel):
@@ -189,35 +307,10 @@ class IcebergFastDataframeModel(FastDataframeModel):
 
     @classmethod
     def iceberg_schema(cls, alias_type: AliasType = "serialization") -> Schema:
-        """Return a pyiceberg Schema based on the model's fields, supporting Optional types."""
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
-        )
-
-        # Create a custom alias function that works with the __pydantic_fields__ format
-        def pydantic_alias_func(field_info: Any, field_name: str) -> str:
-            return alias_func(cls.__pydantic_fields__[field_name], field_name)
-
-        fields = _model_fields_to_iceberg_fields(cls.model_fields, pydantic_alias_func)
-        return Schema(*fields)
+        """Return a pyiceberg Schema based on the model's fields."""
+        return schema(cls, alias_type)
 
     @classmethod
     def validate_schema(cls, table: Table) -> List[ValidationError]:
-        """Validate that the Iceberg table's columns match the model's fields by name only.
-
-        Args:
-            table: The Iceberg table to validate.
-
-        Returns:
-            List[ValidationError]: A list of validation errors (missing columns).
-        """
-
-        table_json_schema = iceberg_schema_to_json_schema(table.schema())
-        model_json_schema = cls.model_json_schema()
-
-        errors = {}
-        errors.update(validate_missing_columns(model_json_schema, table_json_schema))
-
-        return list(errors.values())
+        """Validate that the Iceberg table's columns match the model's fields."""
+        return validate_schema(cls, table, canonical=False)

--- a/src/fastdataframe/polars/__init__.py
+++ b/src/fastdataframe/polars/__init__.py
@@ -1,4 +1,4 @@
-"""Polars integration for FastDataframe."""
+"""Polars integration for FastDataFrame."""
 
 try:
     import polars as pl  # noqa: F401
@@ -7,6 +7,20 @@ except ImportError as e:
         "Polars package is not available. Please install it using 'pip install fastdataframe[polars]'"
     ) from e
 
-from .model import PolarsFastDataframeModel
+from .model import (
+    PolarsFastDataframeModel,
+    cast,
+    rename,
+    schema,
+    string_schema,
+    validate_schema,
+)
 
-__all__ = ["PolarsFastDataframeModel"]
+__all__ = [
+    "PolarsFastDataframeModel",
+    "cast",
+    "rename",
+    "schema",
+    "string_schema",
+    "validate_schema",
+]

--- a/src/fastdataframe/polars/_types.py
+++ b/src/fastdataframe/polars/_types.py
@@ -4,10 +4,27 @@ import polars as pl
 import inspect
 import datetime as dt
 from typing import get_origin, get_args, Any, Union
+from fastdataframe.core.column import ColumnDefinition
+from fastdataframe.core.dtypes import (
+    Binary,
+    Boolean,
+    Date,
+    Decimal,
+    Float32,
+    Float64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Time,
+    Timestamp,
+)
 from fastdataframe.core.pydantic.field_info import (
     get_serialization_alias,
     get_validation_alias,
 )
+from fastdataframe.core.types_helper import unwrap_annotated_optional
 
 type PolarsType = pl.DataType | pl.DataTypeClass
 
@@ -109,6 +126,54 @@ def _handle_basemodel_type(annotation: Any) -> PolarsType | None:
     if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
         return _convert_basemodel_to_struct(annotation)
     return None
+
+
+def get_polars_type_from_column(
+    column: ColumnDefinition, alias_type: str = "serialization"
+) -> PolarsType:
+    """Convert a ColumnDefinition to a Polars type."""
+    dtype = column.info.dtype
+    if dtype is not None:
+        if isinstance(dtype, Boolean):
+            return pl.Boolean
+        if isinstance(dtype, String):
+            return pl.String
+        if isinstance(dtype, Binary):
+            return pl.Binary
+        if isinstance(dtype, Int8):
+            return pl.Int8
+        if isinstance(dtype, Int16):
+            return pl.Int16
+        if isinstance(dtype, Int32):
+            return pl.Int32
+        if isinstance(dtype, Int64):
+            return pl.Int64
+        if isinstance(dtype, Float32):
+            return pl.Float32
+        if isinstance(dtype, Float64):
+            return pl.Float64
+        if isinstance(dtype, Date):
+            return pl.Date
+        if isinstance(dtype, Time):
+            return pl.Time
+        if isinstance(dtype, Timestamp):
+            return pl.Datetime(time_zone=dtype.timezone)
+        if isinstance(dtype, Decimal):
+            return pl.Decimal(dtype.precision, dtype.scale)
+
+    return _annotation_to_polars_type(
+        unwrap_annotated_optional(column.annotation),
+        column.field_info.metadata,
+        alias_type,
+    )
+
+
+def _annotation_to_polars_type(
+    annotation: Any, metadata: list[Any], alias_type: str = "serialization"
+) -> PolarsType:
+    field_info = FieldInfo(annotation=annotation)
+    field_info.metadata = metadata
+    return get_polars_type(field_info, alias_type)
 
 
 def get_polars_type(

--- a/src/fastdataframe/polars/model.py
+++ b/src/fastdataframe/polars/model.py
@@ -178,6 +178,8 @@ def rename(
     df: pl.DataFrame | pl.LazyFrame,
     alias_type_from: AliasType = "serialization",
     alias_type_to: AliasType = "serialization",
+    *,
+    strict: bool = True,
 ) -> pl.DataFrame | pl.LazyFrame:
     """Rename dataframe columns between FastDataFrame name sets."""
     model_map = {
@@ -185,6 +187,10 @@ def rename(
         for column in model.column_definitions
     }
     df_schema = df.collect_schema()
+    missing = set(df_schema.keys()) - set(model_map.keys())
+    if strict and missing:
+        names = ", ".join(sorted(missing))
+        raise KeyError(f"DataFrame contains columns not defined by model: {names}")
     rename_map = {
         field_name: model_map[field_name]
         for field_name in df_schema.keys()
@@ -201,10 +207,11 @@ def cast(
     """Cast DataFrame or LazyFrame columns to match the model schema."""
     source_schema = df.collect_schema()
     target_schema = schema(model, alias_type)
-    column_infos = model.model_columns(alias_type)
     cast_functions = []
 
-    for target_col, target_type in target_schema.items():
+    for column in model.column_definitions:
+        target_col = _column_name(column, alias_type)
+        target_type = target_schema[target_col]
         if target_col not in source_schema:
             raise ValueError(f"Column {target_col} not found in source schema")
         if source_schema[target_col] == target_type:
@@ -218,7 +225,7 @@ def cast(
                 source_schema[target_col],
                 target_type,
                 target_col,
-                column_infos[target_col],
+                column.info,
             )
         )
 
@@ -306,7 +313,7 @@ class PolarsFastDataframeModel(FastDataframeModel):
             df = MyModel.rename(df, alias_type_from='validation', alias_type_to='serialization')
             ```
         """
-        return rename(cls, df, alias_type_from, alias_type_to)
+        return rename(cls, df, alias_type_from, alias_type_to, strict=False)
 
     @classmethod
     def cast(

--- a/src/fastdataframe/polars/model.py
+++ b/src/fastdataframe/polars/model.py
@@ -282,6 +282,8 @@ class PolarsFastDataframeModel(FastDataframeModel):
         df: pl.DataFrame | pl.LazyFrame,
         alias_type_from: AliasType = "serialization",
         alias_type_to: AliasType = "serialization",
+        *,
+        strict: bool = False,
     ) -> pl.DataFrame | pl.LazyFrame:
         """Rename dataframe columns between different alias types according to the model's schema.
 
@@ -296,13 +298,17 @@ class PolarsFastDataframeModel(FastDataframeModel):
                 - 'validation' for validation/processing names
             alias_type_to: The target alias type to convert column names to.
                 Uses same options as alias_type_from.
+            strict: Whether to raise a KeyError when the dataframe contains columns
+                that are not defined by the model. Defaults to False for backwards
+                compatibility with the previous classmethod behavior.
 
         Returns:
             pl.DataFrame | pl.LazyFrame: New dataframe with renamed columns. Maintains original type
             (eager DataFrame or LazyFrame) of input.
 
         Raises:
-            KeyError: If any existing column name is not found in the model's schema
+            KeyError: If strict=True and any existing column name is not found in
+                the model's schema.
 
         Example:
             ```python
@@ -313,7 +319,7 @@ class PolarsFastDataframeModel(FastDataframeModel):
             df = MyModel.rename(df, alias_type_from='validation', alias_type_to='serialization')
             ```
         """
-        return rename(cls, df, alias_type_from, alias_type_to, strict=False)
+        return rename(cls, df, alias_type_from, alias_type_to, strict=strict)
 
     @classmethod
     def cast(

--- a/src/fastdataframe/polars/model.py
+++ b/src/fastdataframe/polars/model.py
@@ -1,25 +1,27 @@
 """PolarsFastDataframeModel implementation."""
 
 from fastdataframe.core.model import AliasType, FastDataframeModel
-from fastdataframe.core.pydantic.field_info import (
-    get_serialization_alias,
-    get_validation_alias,
-)
 from fastdataframe.core.validation import ValidationError, ValidationResult
 import polars as pl
-from typing import TypeVar, Union, Any
-from pydantic import TypeAdapter
+from typing import TypeVar, Union, Any, cast as typing_cast
+from pydantic import BaseModel, TypeAdapter, create_model
 from fastdataframe.core.json_schema import (
     validate_missing_columns,
     validate_column_types,
 )
 from fastdataframe.polars._cast_functions import custom_cast_functions, simple_cast
-from fastdataframe.polars._types import get_polars_type
+from fastdataframe.polars._types import get_polars_type_from_column
 
 TFrame = TypeVar("TFrame", bound=pl.DataFrame | pl.LazyFrame)
 
 # Type alias for JSON schema values (can be dict, list, or primitives)
 JsonSchemaValue = dict[str, Any] | list[Any] | str | int | float | bool | None
+
+
+def _column_name(column: Any, alias_type: AliasType = "serialization") -> str:
+    if alias_type == "validation":
+        return column.validation_name
+    return column.storage_name
 
 
 def _resolve_json_schema_refs(
@@ -105,8 +107,141 @@ def _extract_polars_frame_json_schema(frame: pl.LazyFrame | pl.DataFrame) -> dic
     }
 
 
+def validate_schema(
+    model: type[FastDataframeModel],
+    frame: pl.LazyFrame | pl.DataFrame,
+    *,
+    canonical: bool = True,
+) -> list[ValidationError]:
+    """Validate a Polars frame schema against a FastDataFrame model."""
+    model_json_schema = model.model_json_schema()
+    df_json_schema = _extract_polars_frame_json_schema(frame)
+
+    defs = model_json_schema.get("$defs", {})
+    if defs:
+        resolved_properties = {}
+        for prop_name, prop_schema in model_json_schema.get("properties", {}).items():
+            resolved_properties[prop_name] = _resolve_json_schema_refs(
+                prop_schema, defs
+            )
+        resolved_model_schema = model_json_schema.copy()
+        resolved_model_schema["properties"] = resolved_properties
+        model_json_schema = resolved_model_schema
+
+    if canonical:
+        storage_names = [column.storage_name for column in model.column_definitions]
+        model_json_schema = model_json_schema.copy()
+        model_json_schema["required"] = storage_names
+        if "properties" in model_json_schema:
+            model_json_schema["properties"] = {
+                column.storage_name: model_json_schema["properties"].get(
+                    column.python_name,
+                    model_json_schema["properties"].get(column.storage_name, {}),
+                )
+                for column in model.column_definitions
+            }
+
+    errors = {}
+    errors.update(validate_missing_columns(model_json_schema, df_json_schema))
+    errors.update(validate_column_types(model_json_schema, df_json_schema))
+    return list(errors.values())
+
+
+def schema(
+    model: type[FastDataframeModel], alias_type: AliasType = "serialization"
+) -> pl.Schema:
+    """Generate a Polars schema from a FastDataFrame model."""
+    return pl.Schema(
+        {
+            _column_name(column, alias_type): get_polars_type_from_column(
+                column, alias_type
+            )
+            for column in model.column_definitions
+        }
+    )
+
+
+def string_schema(
+    model: type[FastDataframeModel], alias_type: AliasType = "serialization"
+) -> pl.Schema:
+    """Generate a Polars schema where every model column is String."""
+    return pl.Schema(
+        {
+            _column_name(column, alias_type): pl.String
+            for column in model.column_definitions
+        }
+    )
+
+
+def rename(
+    model: type[FastDataframeModel],
+    df: pl.DataFrame | pl.LazyFrame,
+    alias_type_from: AliasType = "serialization",
+    alias_type_to: AliasType = "serialization",
+) -> pl.DataFrame | pl.LazyFrame:
+    """Rename dataframe columns between FastDataFrame name sets."""
+    model_map = {
+        _column_name(column, alias_type_from): _column_name(column, alias_type_to)
+        for column in model.column_definitions
+    }
+    df_schema = df.collect_schema()
+    rename_map = {
+        field_name: model_map[field_name]
+        for field_name in df_schema.keys()
+        if field_name in model_map
+    }
+    return df.rename(rename_map)
+
+
+def cast(
+    model: type[FastDataframeModel],
+    df: Union[pl.DataFrame, pl.LazyFrame],
+    alias_type: AliasType = "serialization",
+) -> Union[pl.DataFrame, pl.LazyFrame]:
+    """Cast DataFrame or LazyFrame columns to match the model schema."""
+    source_schema = df.collect_schema()
+    target_schema = schema(model, alias_type)
+    column_infos = model.model_columns(alias_type)
+    cast_functions = []
+
+    for target_col, target_type in target_schema.items():
+        if target_col not in source_schema:
+            raise ValueError(f"Column {target_col} not found in source schema")
+        if source_schema[target_col] == target_type:
+            continue
+        cast_function = custom_cast_functions.get(
+            (type(source_schema[target_col]), type(target_type)), simple_cast
+        )
+
+        cast_functions.append(
+            cast_function(
+                source_schema[target_col],
+                target_type,
+                target_col,
+                column_infos[target_col],
+            )
+        )
+
+    return df.with_columns(cast_functions)
+
+
 class PolarsFastDataframeModel(FastDataframeModel):
     """A model that extends FastDataframeModel for Polars integration."""
+
+    @classmethod
+    def from_base_model(cls, model: type[BaseModel]):
+        """Create a Polars-compatible model from a Pydantic model."""
+        field_definitions = {
+            field_name: (field_type.annotation, field_type)
+            for field_name, field_type in model.model_fields.items()
+        }
+        new_model = create_model(  # type: ignore[no-matching-overload]
+            f"{model.__name__}Polars",
+            __base__=cls,
+            __doc__=f"Polars version of {model.__name__}",
+            **field_definitions,
+        )
+        return typing_cast(type[PolarsFastDataframeModel], new_model)
 
     @classmethod
     def validate_schema(
@@ -120,66 +255,19 @@ class PolarsFastDataframeModel(FastDataframeModel):
         Returns:
             List[ValidationError]: A list of validation errors.
         """
-        model_json_schema = cls.model_json_schema()
-        df_json_schema = _extract_polars_frame_json_schema(frame)
-
-        # Resolve $ref references in the model schema to match DataFrame schema format
-        defs = model_json_schema.get("$defs", {})
-        if defs:
-            # Resolve references in properties
-            resolved_properties = {}
-            for prop_name, prop_schema in model_json_schema.get(
-                "properties", {}
-            ).items():
-                resolved_properties[prop_name] = _resolve_json_schema_refs(
-                    prop_schema, defs
-                )
-
-            # Create a new model schema with resolved references
-            resolved_model_schema = model_json_schema.copy()
-            resolved_model_schema["properties"] = resolved_properties
-            model_json_schema = resolved_model_schema
-
-        # Collect all validation errors
-        errors = {}
-        errors.update(validate_missing_columns(model_json_schema, df_json_schema))
-        errors.update(validate_column_types(model_json_schema, df_json_schema))
-
-        return list(errors.values())
+        return validate_schema(cls, frame, canonical=False)
 
     @classmethod
     def get_polars_schema(cls, alias_type: AliasType = "serialization") -> pl.Schema:
         """Get the polars schema for the model."""
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
-        )
-        return pl.Schema(
-            {
-                alias_func(field_info, field_name): get_polars_type(
-                    field_info, alias_type
-                )
-                for field_name, field_info in cls.model_fields.items()
-            }
-        )
+        return schema(cls, alias_type)
 
     @classmethod
     def get_stringified_schema(
         cls, alias_type: AliasType = "serialization"
     ) -> pl.Schema:
         """Get the polars schema for the model with all columns as strings."""
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
-        )
-        return pl.Schema(
-            {
-                alias_func(field_info, field_name): pl.String
-                for field_name, field_info in cls.model_fields.items()
-            }
-        )
+        return string_schema(cls, alias_type)
 
     @classmethod
     def rename(
@@ -218,29 +306,7 @@ class PolarsFastDataframeModel(FastDataframeModel):
             df = MyModel.rename(df, alias_type_from='validation', alias_type_to='serialization')
             ```
         """
-        alias_func_from = (
-            get_serialization_alias
-            if alias_type_from == "serialization"
-            else get_validation_alias
-        )
-        alias_func_to = (
-            get_serialization_alias
-            if alias_type_to == "serialization"
-            else get_validation_alias
-        )
-        model_map = {
-            alias_func_from(field_info, field_name): alias_func_to(
-                field_info, field_name
-            )
-            for field_name, field_info in cls.__pydantic_fields__.items()
-        }
-        df_schema = df.collect_schema()
-        rename_map = {
-            field_name: model_map[field_name]
-            for field_name in df_schema.keys()
-            if field_name in model_map
-        }
-        return df.rename(rename_map)
+        return rename(cls, df, alias_type_from, alias_type_to)
 
     @classmethod
     def cast(
@@ -321,32 +387,7 @@ class PolarsFastDataframeModel(FastDataframeModel):
             - The method preserves the original dataframe's structure and only modifies
               column types as needed
         """
-        source_schema = df.collect_schema()
-        target_schema = cls.get_polars_schema(alias_type)
-        column_infos = cls.model_columns(alias_type)
-        cast_functions = []
-
-        for target_col, target_type in target_schema.items():
-            if target_col not in source_schema:
-                raise ValueError(f"Column {target_col} not found in source schema")
-            if source_schema[target_col] == target_type:
-                continue
-            cast_function = custom_cast_functions.get(
-                (type(source_schema[target_col]), type(target_type)), simple_cast
-            )
-
-            cast_functions.append(
-                cast_function(
-                    source_schema[target_col],
-                    target_type,
-                    target_col,
-                    column_infos[target_col],
-                )
-            )
-
-        df = df.with_columns(cast_functions)
-
-        return df
+        return cast(cls, df, alias_type)
 
     @classmethod
     def validate_data(cls, df: pl.DataFrame) -> ValidationResult:

--- a/src/fastdataframe/pyarrow/__init__.py
+++ b/src/fastdataframe/pyarrow/__init__.py
@@ -1,9 +1,5 @@
-"""PyArrow integration for FastDataframe.
+"""PyArrow integration for FastDataFrame."""
 
-This module provides PyArrow-specific functionality for working with
-Pydantic models as PyArrow schemas.
-"""
+from .model import PyArrowFastDataframeModel, schema, string_schema
 
-from fastdataframe.pyarrow.model import PyArrowFastDataframeModel
-
-__all__ = ["PyArrowFastDataframeModel"]
+__all__ = ["PyArrowFastDataframeModel", "schema", "string_schema"]

--- a/src/fastdataframe/pyarrow/_types.py
+++ b/src/fastdataframe/pyarrow/_types.py
@@ -9,11 +9,27 @@ import pyarrow as pa
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
+from fastdataframe.core.column import ColumnDefinition
+from fastdataframe.core.dtypes import (
+    Binary,
+    Boolean,
+    Date,
+    Decimal,
+    Float32,
+    Float64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    String,
+    Time,
+    Timestamp,
+)
 from fastdataframe.core.pydantic.field_info import (
     get_serialization_alias,
     get_validation_alias,
 )
-from fastdataframe.core.types_helper import is_optional_type
+from fastdataframe.core.types_helper import is_optional_type, unwrap_annotated_optional
 
 type PyArrowType = pa.DataType
 
@@ -149,6 +165,48 @@ def _convert_basemodel_to_struct(
         fields.append(pa.field(field_alias, field_type, nullable=nullable))
 
     return pa.struct(fields)
+
+
+def get_pyarrow_type_from_column(
+    column: ColumnDefinition, alias_type: str = "serialization"
+) -> PyArrowType:
+    """Convert a ColumnDefinition to a PyArrow type."""
+    for metadata in column.field_info.metadata:
+        if isinstance(metadata, pa.DataType):
+            return metadata
+
+    dtype = column.info.dtype
+    if dtype is not None:
+        if isinstance(dtype, Boolean):
+            return pa.bool_()
+        if isinstance(dtype, String):
+            return pa.string()
+        if isinstance(dtype, Binary):
+            return pa.binary()
+        if isinstance(dtype, Int8):
+            return pa.int8()
+        if isinstance(dtype, Int16):
+            return pa.int16()
+        if isinstance(dtype, Int32):
+            return pa.int32()
+        if isinstance(dtype, Int64):
+            return pa.int64()
+        if isinstance(dtype, Float32):
+            return pa.float32()
+        if isinstance(dtype, Float64):
+            return pa.float64()
+        if isinstance(dtype, Date):
+            return pa.date32()
+        if isinstance(dtype, Time):
+            return pa.time64("us")
+        if isinstance(dtype, Timestamp):
+            return pa.timestamp("us", tz=dtype.timezone)
+        if isinstance(dtype, Decimal):
+            return pa.decimal128(dtype.precision, dtype.scale)
+
+    return _python_type_to_pyarrow(
+        unwrap_annotated_optional(column.annotation), alias_type
+    )
 
 
 def get_pyarrow_type(

--- a/src/fastdataframe/pyarrow/model.py
+++ b/src/fastdataframe/pyarrow/model.py
@@ -1,121 +1,76 @@
-"""PyArrowFastDataframeModel implementation."""
+"""PyArrow integration for FastDataFrame."""
+
+from __future__ import annotations
+
+from typing import cast as typing_cast
 
 import pyarrow as pa
+from pydantic import BaseModel, create_model
 
 from fastdataframe.core.model import AliasType, FastDataframeModel
-from fastdataframe.core.pydantic.field_info import (
-    get_serialization_alias,
-    get_validation_alias,
-)
-from fastdataframe.core.types_helper import is_optional_type
-from fastdataframe.pyarrow._types import get_pyarrow_type
+from fastdataframe.pyarrow._types import get_pyarrow_type_from_column
+
+
+def _column_name(column, alias_type: AliasType = "serialization") -> str:
+    if alias_type == "validation":
+        return column.validation_name
+    return column.storage_name
+
+
+def schema(
+    model: type[FastDataframeModel], alias_type: AliasType = "serialization"
+) -> pa.Schema:
+    """Get the PyArrow schema for a FastDataFrame model."""
+    fields = [
+        pa.field(
+            _column_name(column, alias_type),
+            get_pyarrow_type_from_column(column, alias_type),
+            nullable=column.nullable,
+        )
+        for column in model.column_definitions
+    ]
+    return pa.schema(fields)
+
+
+def string_schema(
+    model: type[FastDataframeModel], alias_type: AliasType = "serialization"
+) -> pa.Schema:
+    """Get the PyArrow schema for the model with all columns as strings."""
+    fields = [
+        pa.field(
+            _column_name(column, alias_type), pa.string(), nullable=column.nullable
+        )
+        for column in model.column_definitions
+    ]
+    return pa.schema(fields)
 
 
 class PyArrowFastDataframeModel(FastDataframeModel):
     """A model that extends FastDataframeModel for PyArrow integration."""
 
     @classmethod
-    def get_pyarrow_schema(cls, alias_type: AliasType = "serialization") -> pa.Schema:
-        """Get the PyArrow schema for the model.
-
-        This method generates a PyArrow schema based on the model's field definitions,
-        including proper type mappings and nullability information. The schema can be
-        used for creating Arrow tables, reading/writing Parquet files, and integrating
-        with other Arrow-based systems.
-
-        Args:
-            alias_type: The alias type to use for field names.
-                - 'serialization' (default): Use serialization aliases for field names
-                - 'validation': Use validation aliases for field names
-
-        Returns:
-            pa.Schema: A PyArrow Schema object representing the model's structure.
-
-        Example:
-            ```python
-            from fastdataframe.pyarrow.model import PyArrowFastDataframeModel
-            from typing import Optional
-
-            class UserModel(PyArrowFastDataframeModel):
-                id: int
-                name: str
-                email: Optional[str] = None
-                is_active: bool
-
-            # Get the schema
-            schema = UserModel.get_pyarrow_schema()
-
-            # Use with PyArrow
-            import pyarrow as pa
-            table = pa.table({
-                "id": [1, 2, 3],
-                "name": ["Alice", "Bob", "Charlie"],
-                "email": ["alice@example.com", None, "charlie@example.com"],
-                "is_active": [True, True, False]
-            }, schema=schema)
-            ```
-
-        Notes:
-            - Required fields (non-Optional) have nullable=False in the schema
-            - Optional fields have nullable=True in the schema
-            - Collection types (list, set, tuple) are mapped to pa.list_()
-            - Pydantic BaseModel fields are mapped to pa.struct()
-            - The schema preserves field order as defined in the model
-        """
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
+    def from_base_model(cls, model: type[BaseModel]):
+        """Create a PyArrow-compatible model from a Pydantic model."""
+        field_definitions = {
+            field_name: (field_type.annotation, field_type)
+            for field_name, field_type in model.model_fields.items()
+        }
+        new_model = create_model(  # type: ignore[no-matching-overload]
+            f"{model.__name__}PyArrow",
+            __base__=cls,
+            __doc__=f"PyArrow version of {model.__name__}",
+            **field_definitions,
         )
+        return typing_cast(type[PyArrowFastDataframeModel], new_model)
 
-        fields = []
-        for field_name, field_info in cls.model_fields.items():
-            field_alias = alias_func(field_info, field_name)
-            pa_type = get_pyarrow_type(field_info, alias_type)
-            nullable = is_optional_type(field_info.annotation)
-            fields.append(pa.field(field_alias, pa_type, nullable=nullable))
-
-        return pa.schema(fields)
+    @classmethod
+    def get_pyarrow_schema(cls, alias_type: AliasType = "serialization") -> pa.Schema:
+        """Get the PyArrow schema for the model."""
+        return schema(cls, alias_type)
 
     @classmethod
     def get_stringified_schema(
         cls, alias_type: AliasType = "serialization"
     ) -> pa.Schema:
-        """Get the PyArrow schema for the model with all columns as strings.
-
-        This is useful when reading data from sources where all values are strings
-        (like CSV files) and need to be cast to the proper types later.
-
-        Args:
-            alias_type: The alias type to use for field names.
-                - 'serialization' (default): Use serialization aliases for field names
-                - 'validation': Use validation aliases for field names
-
-        Returns:
-            pa.Schema: A PyArrow Schema with all fields as pa.string() type.
-
-        Example:
-            ```python
-            class UserModel(PyArrowFastDataframeModel):
-                id: int
-                name: str
-                score: float
-
-            # Get stringified schema for reading CSV
-            string_schema = UserModel.get_stringified_schema()
-            # All fields will be pa.string()
-            ```
-        """
-        alias_func = (
-            get_serialization_alias
-            if alias_type == "serialization"
-            else get_validation_alias
-        )
-
-        fields = []
-        for field_name, field_info in cls.model_fields.items():
-            field_alias = alias_func(field_info, field_name)
-            nullable = is_optional_type(field_info.annotation)
-            fields.append(pa.field(field_alias, pa.string(), nullable=nullable))
-
-        return pa.schema(fields)
+        """Get the PyArrow schema for the model with all columns as strings."""
+        return string_schema(cls, alias_type)

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import pytest
-from fastdataframe import ColumnInfo
+from fastdataframe import ColumnInfo, Int32
 
 
 class TestColumnInfo:
@@ -33,25 +33,23 @@ class TestColumnInfo:
         doc = extra["_fastdataframe"]
         assert doc["type"] == "FastDataframe"
         assert doc["version"] == "1.0"
-        assert doc["properties"] == {"is_unique": True}
+        assert doc["properties"]["is_unique"] is True
+        assert doc["properties"]["deprecated"] is False
 
     def test_fastdataframe_from_schema(self) -> None:
         """Test that FastDataframe can be reconstructed from schema."""
-        # Create a schema with FastDataframe metadata
-        schema = {
-            "json_schema_extra": {
-                "is_unique": True,
-                "_fastdataframe": {
-                    "type": "FastDataframe",
-                    "version": "1.0",
-                    "properties": {"is_unique": True},
-                },
-            }
-        }
+        metadata = ColumnInfo(
+            is_unique=True,
+            bool_true_string="yes",
+            bool_false_string="no",
+            dtype=Int32(),
+            deprecated=True,
+            iceberg_id=7,
+        )
+        schema = {"json_schema_extra": metadata.as_field_metadata()}
 
-        # Reconstruct FastDataframe from schema
-        metadata = ColumnInfo.from_schema(schema)
-        assert metadata.is_unique is True
+        reconstructed = ColumnInfo.from_schema(schema)
+        assert reconstructed == metadata
 
     def test_fastdataframe_from_schema_invalid_type(self) -> None:
         """Test that FastDataframe.from_schema raises error for invalid type."""

--- a/tests/core/test_rewrite_features.py
+++ b/tests/core/test_rewrite_features.py
@@ -53,6 +53,13 @@ class TestColumnDefinitions:
         assert isinstance(column.info, ColumnInfo)
         assert column.info.dtype is None
 
+    def test_integer_dtype_rejects_bool_annotation(self) -> None:
+        class Invalid(FastDataFrameModel):
+            flag: Annotated[bool, ColumnInfo(dtype=Int32())]
+
+        with pytest.raises(ValueError, match="not compatible"):
+            _ = Invalid.column_definitions
+
     def test_dtype_must_be_compatible_with_annotation(self) -> None:
         class Valid(FastDataFrameModel):
             user_id: Annotated[int, ColumnInfo(dtype=Int32())]

--- a/tests/core/test_rewrite_features.py
+++ b/tests/core/test_rewrite_features.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, Field
+
+from fastdataframe import ColumnInfo, FastDataFrameModel, Int16, Int32, String
+
+
+class TestColumnDefinitions:
+    def test_model_owns_immutable_column_definitions(self) -> None:
+        class User(FastDataFrameModel):
+            user_id: Annotated[int, Field(serialization_alias="user_id")]
+            name: str
+
+        columns = User.column_definitions
+
+        assert isinstance(columns, tuple)
+        assert columns[0].python_name == "user_id"
+        assert columns[0].storage_name == "user_id"
+        assert columns[0].nullable is False
+        with pytest.raises(FrozenInstanceError):
+            columns[0].python_name = "other"  # type: ignore[misc]
+
+    def test_from_base_model_creates_backend_neutral_model(self) -> None:
+        class User(BaseModel):
+            user_id: Annotated[int, Field(serialization_alias="user_id")]
+
+        FastUser = FastDataFrameModel.from_base_model(User)
+
+        assert issubclass(FastUser, FastDataFrameModel)
+        assert FastUser.__name__ == "UserFastDataFrame"
+        assert not hasattr(User, "column_definitions")
+        assert FastUser.column_definitions[0].storage_name == "user_id"
+
+    def test_column_info_is_optional_and_defaulted(self) -> None:
+        class User(FastDataFrameModel):
+            user_id: int
+
+        column = User.column_definitions[0]
+
+        assert isinstance(column.info, ColumnInfo)
+        assert column.info.dtype is None
+
+    def test_dtype_must_be_compatible_with_annotation(self) -> None:
+        class Valid(FastDataFrameModel):
+            user_id: Annotated[int, ColumnInfo(dtype=Int32())]
+
+        assert Valid.column_definitions[0].info.dtype == Int32()
+
+        class Invalid(FastDataFrameModel):
+            user_id: Annotated[str, ColumnInfo(dtype=Int32())]
+
+        with pytest.raises(ValueError, match="not compatible"):
+            _ = Invalid.column_definitions
+
+    def test_defaults_and_nullability_are_separate(self) -> None:
+        class User(FastDataFrameModel):
+            required_non_null: int
+            default_non_null: int = 0
+            nullable_required: int | None
+            nullable_default: int | None = None
+
+        columns = {column.python_name: column for column in User.column_definitions}
+
+        assert columns["required_non_null"].required_input is True
+        assert columns["required_non_null"].nullable is False
+        assert columns["default_non_null"].required_input is False
+        assert columns["default_non_null"].nullable is False
+        assert columns["nullable_required"].required_input is True
+        assert columns["nullable_required"].nullable is True
+        assert columns["nullable_default"].required_input is False
+        assert columns["nullable_default"].nullable is True
+
+
+class TestNameAccessors:
+    def test_name_accessors_use_python_field_names(self) -> None:
+        class User(FastDataFrameModel):
+            user_id: Annotated[
+                int,
+                Field(validation_alias="userId", serialization_alias="USER_ID"),
+            ]
+
+        assert User.serialization_names.user_id == "USER_ID"
+        assert User.validation_names.user_id == "userId"
+        assert User.storage_names.user_id == "USER_ID"
+        assert User.serialization_names["user_id"] == "USER_ID"
+
+    def test_name_accessors_are_immutable(self) -> None:
+        class User(FastDataFrameModel):
+            user_id: int
+
+        with pytest.raises(AttributeError):
+            User.serialization_names.user_id = "other"  # type: ignore[misc]
+
+
+class TestColumnLifecycle:
+    def test_deprecated_field_must_be_nullable(self) -> None:
+        class Valid(FastDataFrameModel):
+            old_value: Annotated[int | None, ColumnInfo(deprecated=True)]
+
+        assert Valid.column_definitions[0].deprecated is True
+        assert Valid.serialization_names.old_value == "old_value"
+
+        class Invalid(FastDataFrameModel):
+            old_value: Annotated[int, ColumnInfo(deprecated=True)]
+
+        with pytest.raises(ValueError, match="Deprecated field"):
+            _ = Invalid.column_definitions
+
+    def test_reserved_removed_names_cannot_be_reused(self) -> None:
+        class DeprecatedName(FastDataFrameModel):
+            model_config = {"fastdataframe_deprecated_column_names": {"old_value"}}
+            old_value: int
+
+        with pytest.raises(ValueError, match="Reserved column names"):
+            _ = DeprecatedName.column_definitions
+
+        class RemovedName(FastDataFrameModel):
+            model_config = {"fastdataframe_removed_column_names": {"old_value"}}
+            old_value: int
+
+        with pytest.raises(ValueError, match="Reserved column names"):
+            _ = RemovedName.column_definitions
+
+
+def test_different_dtype_can_refine_same_python_annotation() -> None:
+    class User(FastDataFrameModel):
+        small: Annotated[int, ColumnInfo(dtype=Int16())]
+        normal: Annotated[int, ColumnInfo(dtype=Int32())]
+        label: Annotated[str, ColumnInfo(dtype=String())]
+
+    columns = {column.python_name: column for column in User.column_definitions}
+
+    assert columns["small"].info.dtype == Int16()
+    assert columns["normal"].info.dtype == Int32()
+    assert columns["label"].info.dtype == String()

--- a/tests/core/test_rewrite_features.py
+++ b/tests/core/test_rewrite_features.py
@@ -35,6 +35,15 @@ class TestColumnDefinitions:
         assert not hasattr(User, "column_definitions")
         assert FastUser.column_definitions[0].storage_name == "user_id"
 
+    def test_column_info_can_come_from_field_json_schema_extra(self) -> None:
+        class User(FastDataFrameModel):
+            user_id: Annotated[
+                int,
+                Field(json_schema_extra=ColumnInfo(dtype=Int32()).as_field_metadata()),
+            ]
+
+        assert User.column_definitions[0].info.dtype == Int32()
+
     def test_column_info_is_optional_and_defaulted(self) -> None:
         class User(FastDataFrameModel):
             user_id: int
@@ -110,20 +119,27 @@ class TestColumnLifecycle:
         with pytest.raises(ValueError, match="Deprecated field"):
             _ = Invalid.column_definitions
 
-    def test_reserved_removed_names_cannot_be_reused(self) -> None:
-        class DeprecatedName(FastDataFrameModel):
-            model_config = {"fastdataframe_deprecated_column_names": {"old_value"}}
+    @pytest.mark.parametrize(
+        "config_key",
+        [
+            "fastdataframe_deprecated_column_names",
+            "fastdataframe_removed_column_names",
+        ],
+    )
+    def test_reserved_removed_names_cannot_be_reused(self, config_key: str) -> None:
+        class ReservedName(FastDataFrameModel):
+            model_config = {config_key: {"old_value"}}
             old_value: int
 
         with pytest.raises(ValueError, match="Reserved column names"):
-            _ = DeprecatedName.column_definitions
+            _ = ReservedName.column_definitions
 
-        class RemovedName(FastDataFrameModel):
-            model_config = {"fastdataframe_removed_column_names": {"old_value"}}
+    def test_string_config_value_is_ignored_for_reserved_names(self) -> None:
+        class User(FastDataFrameModel):
+            model_config = {"fastdataframe_removed_column_names": "old_value"}
             old_value: int
 
-        with pytest.raises(ValueError, match="Reserved column names"):
-            _ = RemovedName.column_definitions
+        assert User.column_definitions[0].storage_name == "old_value"
 
 
 def test_different_dtype_can_refine_same_python_annotation() -> None:

--- a/tests/iceberg/test_functional_api.py
+++ b/tests/iceberg/test_functional_api.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pyiceberg.types import IntegerType, LongType
+
+from fastdataframe import ColumnInfo, FastDataFrameModel, Int16, Int64
+import fastdataframe.iceberg as fice
+
+
+class User(FastDataFrameModel):
+    small_id: Annotated[int, ColumnInfo(dtype=Int16(), iceberg_id=10)]
+    large_id: Annotated[int, ColumnInfo(dtype=Int64())]
+
+
+def test_functional_schema_uses_dtype_widening_and_optional_field_id() -> None:
+    schema = fice.schema(User)
+
+    small = schema.find_field("small_id")
+    large = schema.find_field("large_id")
+
+    assert small.field_id == 10
+    assert isinstance(small.field_type, IntegerType)
+    assert isinstance(large.field_type, LongType)

--- a/tests/polars/test_functional_api.py
+++ b/tests/polars/test_functional_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 import polars as pl
+import pytest
 
 from fastdataframe import ColumnInfo, FastDataFrameModel, Int16
 import fastdataframe.polars as fpl
@@ -30,6 +31,13 @@ def test_functional_validate_schema_is_canonical() -> None:
 
     assert len(errors) == 1
     assert errors[0].column_name == "score"
+
+
+def test_functional_rename_is_strict_by_default() -> None:
+    df = pl.DataFrame({"user_id": [1], "extra": [1]})
+
+    with pytest.raises(KeyError, match="extra"):
+        fpl.rename(User, df)
 
 
 def test_functional_cast_uses_dtype() -> None:

--- a/tests/polars/test_functional_api.py
+++ b/tests/polars/test_functional_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import polars as pl
+
+from fastdataframe import ColumnInfo, FastDataFrameModel, Int16
+import fastdataframe.polars as fpl
+
+
+class User(FastDataFrameModel):
+    user_id: Annotated[int, ColumnInfo(dtype=Int16())]
+    score: float = 0.0
+
+
+def test_functional_schema_uses_column_definitions_and_dtype() -> None:
+    assert fpl.schema(User) == pl.Schema({"user_id": pl.Int16, "score": pl.Float64})
+
+
+def test_functional_string_schema() -> None:
+    assert fpl.string_schema(User) == pl.Schema(
+        {"user_id": pl.String, "score": pl.String}
+    )
+
+
+def test_functional_validate_schema_is_canonical() -> None:
+    df = pl.DataFrame({"user_id": [1]})
+
+    errors = fpl.validate_schema(User, df)
+
+    assert len(errors) == 1
+    assert errors[0].column_name == "score"
+
+
+def test_functional_cast_uses_dtype() -> None:
+    df = pl.DataFrame({"user_id": ["1"], "score": ["1.5"]})
+
+    result = fpl.cast(User, df)
+
+    assert result.schema["user_id"] == pl.Int16
+    assert result.schema["score"] == pl.Float64

--- a/tests/pyarrow/test_functional_api.py
+++ b/tests/pyarrow/test_functional_api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import pyarrow as pa
+
+from fastdataframe import ColumnInfo, FastDataFrameModel, Int16
+import fastdataframe.pyarrow as farrow
+
+
+class User(FastDataFrameModel):
+    user_id: Annotated[int, ColumnInfo(dtype=Int16())]
+    score: float = 0.0
+    nickname: str | None = None
+
+
+def test_functional_schema_uses_dtype_and_nullability() -> None:
+    schema = farrow.schema(User)
+
+    assert schema.field("user_id").type == pa.int16()
+    assert schema.field("user_id").nullable is False
+    assert schema.field("score").nullable is False
+    assert schema.field("nickname").nullable is True
+
+
+def test_functional_string_schema_preserves_nullability() -> None:
+    schema = farrow.string_schema(User)
+
+    assert schema.field("user_id").type == pa.string()
+    assert schema.field("user_id").nullable is False
+    assert schema.field("nickname").type == pa.string()
+    assert schema.field("nickname").nullable is True


### PR DESCRIPTION
## Summary

Implements the FastDataFrame rewrite PRD across the core model and supported backends.

Highlights:

- Adds backend-neutral `ColumnDefinition`s owned by `FastDataFrameModel`.
- Adds optional `ColumnInfo.dtype`, deprecated field metadata, and optional Iceberg field IDs.
- Adds immutable name accessors: `serialization_names`, `validation_names`, `storage_names`, `python_names`.
- Adds backend-neutral scalar dtypes.
- Adds stateless functional schema APIs for Polars, PyArrow, and Iceberg.
- Adds functional Polars string schema/casting/validation API.
- Adds PyArrow schema/nullability boundary.
- Adds additive-only Iceberg migration helper and Polars-to-Iceberg append through PyArrow schema.
- Documents the rewrite in `README.md`, `CONTEXT.md`, and the PRD.

## Issues

Closes #55
Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #65

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests/ -q`

Result: 373 passed, 9 warnings from PyIceberg/Pydantic deprecations.

## Notes

This PR preserves existing backend model class APIs where tests currently depend on them, while introducing the new stateless functional APIs for the rewrite path.

Please wait for CodeRabbit review and CI before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend-neutral dtype system and per-column dtype refinement; ColumnInfo supports deprecated flag and Iceberg field IDs
  * Immutable column-definition model and name-accessor maps with cached schema metadata; per-backend schema helpers for Polars, PyArrow, Iceberg

* **Documentation**
  * Added architecture/context guide and PRD; README rewritten with backend sections and updated install/dev instructions

* **API Changes**
  * Expanded public exports to include dtypes, column definitions, and integration helpers

* **Tests**
  * New tests covering column definitions, lifecycle rules, name accessors, and Polars/PyArrow/Iceberg functional APIs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davzucky/fastdataframe/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->